### PR TITLE
[LIME-1] 일부 버그 수정. redirect 에 토큰 정보 쿠키로 전달

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/global/config/security/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/config/security/auth/handler/OAuth2LoginSuccessHandler.java
@@ -62,7 +62,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 	) throws IOException {
 		String accessToken = jwtService.generateAccessToken(String.valueOf(oauth2User.getMemberId()));
 		response.addCookie(new Cookie("access-token", accessToken));
-		response.sendRedirect("/api/members/profile"); //인적사항을 입력하는 곳으로 리다이렉트시킴
+		response.sendRedirect("http:localhost:3000/join"); //인적사항을 입력하는 곳으로 리다이렉트시킴
 
 		jwtService.sendAccessToken(response, accessToken);
 	}

--- a/lime-api/src/main/java/com/programmers/lime/global/config/security/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/config/security/auth/handler/OAuth2LoginSuccessHandler.java
@@ -17,6 +17,7 @@ import com.programmers.lime.domains.auth.CustomOauth2User;
 import com.programmers.lime.global.config.security.jwt.JwtService;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -45,10 +46,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 			if (oauth2User.getRole() == Role.GUEST) {
 				log.info("기본 인적사항은 업데이트 하지 않은 유저");
-				String accessToken = jwtService.generateAccessToken(String.valueOf(oauth2User.getMemberId()));
-				response.addHeader("Authorization", "Bearer " + accessToken);
-				response.sendRedirect("/api/members/profile"); //인적사항을 입력하는 곳으로 리다이렉트시킴
-				jwtService.sendAccessToken(response, accessToken);
+				signUpSuccess(response, oauth2User);
 			} else {
 				log.info("기본 인적사항이 등록된 유저");
 				loginSuccess(response, oauth2User);
@@ -56,6 +54,17 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 		} catch (Exception e) {
 			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	private void signUpSuccess(
+		final HttpServletResponse response,
+		final CustomOauth2User oauth2User
+	) throws IOException {
+		String accessToken = jwtService.generateAccessToken(String.valueOf(oauth2User.getMemberId()));
+		response.addCookie(new Cookie("access-token", accessToken));
+		response.sendRedirect("/api/members/profile"); //인적사항을 입력하는 곳으로 리다이렉트시킴
+
+		jwtService.sendAccessToken(response, accessToken);
 	}
 
 	private void loginSuccess(

--- a/lime-api/src/main/java/com/programmers/lime/global/config/security/jwt/JwtService.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/config/security/jwt/JwtService.java
@@ -1,12 +1,8 @@
 package com.programmers.lime.global.config.security.jwt;
 
-import static com.programmers.lime.domains.member.api.MemberController.*;
-import static org.springframework.http.HttpHeaders.*;
-
 import java.security.Key;
 import java.util.Date;
 
-import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 import io.jsonwebtoken.Claims;
@@ -16,7 +12,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -111,36 +106,5 @@ public class JwtService {
 	private Key getSignInKey(final String secretKey) {
 		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
 		return Keys.hmacShaKeyFor(keyBytes);
-	}
-
-	public void sendAccessToken(
-		final HttpServletResponse response,
-		final String accessToken
-	) {
-		response.setStatus(HttpServletResponse.SC_OK);
-
-		response.setHeader("Authorization", accessToken);
-		log.info("재발급된 Access Token : {}", accessToken);
-	}
-
-	public void sendAccessAndRefreshToken(
-		final HttpServletResponse response,
-		final String accessToken,
-		final String refreshToken
-	){
-		response.setStatus(HttpServletResponse.SC_OK);
-
-		final ResponseCookie cookie = ResponseCookie.from("refresh-token", refreshToken)
-			.maxAge(COOKIE_AGE_SECONDS)
-			.secure(true)
-			.httpOnly(true)
-			.sameSite("None")
-			.path("/")
-			.build();
-
-		response.addHeader("Authorization", "Bearer " + accessToken);
-		response.addHeader(SET_COOKIE, String.valueOf(cookie));
-
-		log.info("Access Token, Refresh 설정 완료");
 	}
 }

--- a/lime-api/src/main/java/com/programmers/lime/global/config/security/jwt/JwtService.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/config/security/jwt/JwtService.java
@@ -129,7 +129,6 @@ public class JwtService {
 		final String refreshToken
 	){
 		response.setStatus(HttpServletResponse.SC_OK);
-		response.setHeader("Authorization", accessToken);
 
 		final ResponseCookie cookie = ResponseCookie.from("refresh-token", refreshToken)
 			.maxAge(COOKIE_AGE_SECONDS)


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME-1

### 기능 설명

1. 헤더에 accessToken이 프로필 등록 이후 두번 보내지는 문제 수정,
2. redirect를 할 경우 헤더에 있는 정보는 새로운 요청을 생성할 때 저장할 수 없고 삭제된다.이 방법을 쿠키로 해결함
쿠키로 전달하게 되면서 쿠키의 사용 시간동안 요청이 끝나고 새로운 요청이 만들어져도 살아있을 수 있어 프론트는 해당 정보를 저장할 수 있을 것으로 기대됨


<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
