### PR TITLE
[LIME-50] 아이템 목록 조회 정렬 조건 추가

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
@@ -111,7 +111,8 @@ public class ItemController {
 	) {
 		ItemGetByCursorServiceResponse serviceResponse = itemService.getItemsByCursor(
 			keyword,
-			request.toParameters()
+			request.toParameters(),
+			request.itemSortCondition()
 		);
 		ItemGetByCursorResponse response = ItemGetByCursorResponse.from(serviceResponse);
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
@@ -107,12 +107,13 @@ public class ItemController {
 	@GetMapping("/search")
 	public ResponseEntity<ItemGetByCursorResponse> getItemsByCursor(
 		@RequestParam final String keyword,
-		@ModelAttribute("request") @Valid final CursorRequest request
+		@ModelAttribute("request") @Valid final CursorRequest request,
+		@RequestParam(required = false) final String itemSortCondition
 	) {
 		ItemGetByCursorServiceResponse serviceResponse = itemService.getItemsByCursor(
 			keyword,
 			request.toParameters(),
-			request.itemSortCondition()
+			itemSortCondition
 		);
 		ItemGetByCursorResponse response = ItemGetByCursorResponse.from(serviceResponse);
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
@@ -25,6 +25,7 @@ import com.programmers.lime.domains.item.implementation.MemberItemReader;
 import com.programmers.lime.domains.item.implementation.MemberItemRemover;
 import com.programmers.lime.domains.item.model.ItemCursorSummary;
 import com.programmers.lime.domains.item.model.ItemInfo;
+import com.programmers.lime.domains.item.model.ItemSortCondition;
 import com.programmers.lime.domains.item.model.MemberItemIdRegistry;
 import com.programmers.lime.domains.item.model.MemberItemFavoriteInfo;
 import com.programmers.lime.domains.review.implementation.ReviewReader;
@@ -134,11 +135,15 @@ public class ItemService {
 
 	public ItemGetByCursorServiceResponse getItemsByCursor(
 		final String keyword,
-		final CursorPageParameters parameters
+		final CursorPageParameters parameters,
+		final String itemSortCondition
 	) {
+		ItemSortCondition sortCondition = ItemSortCondition.from(itemSortCondition);
+
 		CursorSummary<ItemCursorSummary> itemCursorSummaryCursorSummary = itemCursorReader.readByCursor(
 			keyword,
-			parameters
+			parameters,
+			sortCondition
 		);
 
 		int itemTotalCount = itemReader.getItemTotalCountByKeyword(keyword);

--- a/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
@@ -10,7 +10,10 @@ public record CursorRequest(
 	String cursorId,
 
 	@Schema(description = "페이징 사이즈입니다", example = "10")
-	Integer size
+	Integer size,
+
+	@Schema(description = "아이템 정렬 방식입니다", example = "REVIEW_COUNT_ASC")
+	String itemSortCondition
 
 ) {
 	public CursorPageParameters toParameters() {

--- a/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
@@ -10,11 +10,7 @@ public record CursorRequest(
 	String cursorId,
 
 	@Schema(description = "페이징 사이즈입니다", example = "10")
-	Integer size,
-
-	@Schema(description = "아이템 정렬 방식입니다", example = "REVIEW_COUNT_ASC")
-	String itemSortCondition
-
+	Integer size
 ) {
 	public CursorPageParameters toParameters() {
 		return new CursorPageParameters(cursorId, size);

--- a/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
+++ b/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
 	ITEM_MARKET_NOT_FOUND("ITEM_001", "지원하지 않는 아이템 URL 입니다."),
 	ITEM_NOT_FOUND("ITEM_002", "요청한 아이템은 찾을 수 없습니다."),
 	ITEM_URL_ALREADY_EXIST("ITEM_003", "이미 존재하는 아이템 URL 입니다."),
+	ITEM_BAD_SORT_CONDITION("ITEM_004", "잘못된 아이템 정렬 조건 입니다."),
 
 	// REVIEW
 	REVIEW_NOT_FOUND("REVIEW_001", "해당하는 리뷰는 찾을 수 없습니다."),

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemCursorReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemCursorReader.java
@@ -10,6 +10,7 @@ import com.programmers.lime.common.cursor.CursorPageParameters;
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.common.cursor.CursorUtils;
 import com.programmers.lime.domains.item.model.ItemCursorSummary;
+import com.programmers.lime.domains.item.model.ItemSortCondition;
 import com.programmers.lime.domains.item.repository.ItemRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,8 @@ public class ItemCursorReader {
 
 	public CursorSummary<ItemCursorSummary> readByCursor(
 		final String keyword,
-		final CursorPageParameters parameters
+		final CursorPageParameters parameters,
+		final ItemSortCondition itemSortCondition
 	) {
 		String trimmedKeyword = keyword.trim();
 
@@ -41,7 +43,8 @@ public class ItemCursorReader {
 		List<ItemCursorSummary> itemCursorSummaries = itemRepository.findAllByCursor(
 			trimmedKeyword,
 			parameters.cursorId(),
-			pageSize
+			pageSize,
+			itemSortCondition
 		);
 
 		return CursorUtils.getCursorSummaries(itemCursorSummaries);

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemSortCondition.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemSortCondition.java
@@ -27,7 +27,7 @@ public enum ItemSortCondition {
 
 	public static ItemSortCondition from(String sortCondition) {
 		if (sortCondition == null) {
-			throw new BusinessException(ErrorCode.ITEM_BAD_SORT_CONDITION);
+			return null;
 		}
 
 		if (SORT_CONDITION_MAP.containsKey(sortCondition)) {

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemSortCondition.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemSortCondition.java
@@ -1,0 +1,39 @@
+package com.programmers.lime.domains.item.model;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.ErrorCode;
+
+public enum ItemSortCondition {
+	REVIEW_COUNT_DESC,
+	REVIEW_RATING_DESC,
+	NEWEST,
+	PRICE_HIGH_TO_LOW,
+	PRICE_LOW_TO_HIGH;
+
+	private static final Map<String, ItemSortCondition> SORT_CONDITION_MAP;
+
+	static {
+		SORT_CONDITION_MAP = Collections.unmodifiableMap(
+			Stream.of(ItemSortCondition.values())
+				.collect(Collectors.toMap(ItemSortCondition::name, Function.identity()))
+		);
+	}
+
+	public static ItemSortCondition from(String sortCondition) {
+		if (sortCondition == null) {
+			throw new BusinessException(ErrorCode.ITEM_BAD_SORT_CONDITION);
+		}
+
+		if (SORT_CONDITION_MAP.containsKey(sortCondition)) {
+			return SORT_CONDITION_MAP.get(sortCondition);
+		}
+
+		throw new BusinessException(ErrorCode.ITEM_BAD_SORT_CONDITION);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursor.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursor.java
@@ -5,12 +5,14 @@ import java.util.List;
 import com.programmers.lime.common.model.Hobby;
 import com.programmers.lime.domains.inventory.model.InventoryReviewItemSummary;
 import com.programmers.lime.domains.item.model.ItemCursorSummary;
+import com.programmers.lime.domains.item.model.ItemSortCondition;
 
 public interface ItemRepositoryForCursor {
 	List<ItemCursorSummary> findAllByCursor(
 		String keyword,
 		String cursorId,
-		int pageSize
+		int pageSize,
+		final ItemSortCondition itemSortCondition
 	);
 
 	List<InventoryReviewItemSummary> findReviewedItemByCursor(

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursorImpl.java
@@ -107,6 +107,9 @@ public class ItemRepositoryForCursorImpl implements ItemRepositoryForCursor {
 	}
 
 	private OrderSpecifier<?> orderBySortCondition(ItemSortCondition itemSortCondition) {
+
+		if (itemSortCondition == null) return new OrderSpecifier<>(Order.DESC, item.createdAt);
+
 		return switch (itemSortCondition) {
 			case REVIEW_COUNT_DESC -> new OrderSpecifier<>(Order.DESC, review.count());
 			case REVIEW_RATING_DESC -> new OrderSpecifier<>(Order.DESC, review.rating.avg());


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

#### 아이템 목록 조회 정렬 조건 추가 😊❤

### Issue Number

LIME -50 

### 기능 설명 

#### 추가 된 정렬 조건❤😊
REVIEW_COUNT_DESC(아이템 리뷰 많은 순 정렬),
REVIEW_RATING_DESC(아이템 리뷰 평점 높은 순 정렬),
NEWEST(최신 순 정렬),
PRICE_HIGH_TO_LOW(아이템 가격 높은 순 정렬),
PRICE_LOW_TO_HIGH(아이템 가격 낮은 순 정렬);

#### 정렬 기능 코드 설명❤😊  233c9d60e52b315f86b4a491ad08b63dbe7615d2.
- 정렬할 때 review 테이블의 정보가 필요하여 item id를 기준으로 item과 review를 join 하였습니다. 
- item에 대해 review가 있는 경우 join을 하고 없는 경우에도 item을 조회할 수 있도록 leftjoin을 추가하였습니다
- item id 기준으로 group by 하여 집계 함수를 사용하였고 이를 기준으로 정렬 하도록 하였습니다. 

#### 정렬 조건 없는 경우 최신순으로 반환 ❤😊 2cf3c5bdf7fb089b0f3cbf4860fc95e6586fb6dd
- 정렬 조건이 없는 경우 아이템이 추가 된 순서대로 반환 됩니다. 

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
