### PR TITLE
[LIME-57] 아이템 목록 조회에 찜 개수, 리뷰 수 추가

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
@@ -142,10 +142,11 @@ public class ItemService {
 		final String itemSortCondition,
 		final String hobbyName
 	) {
+		// 입력 받은 string을 enum으로 변환 (hobbyName, itemSortCondition)
 		Hobby hobby = Hobby.from(hobbyName);
-
 		ItemSortCondition sortCondition = ItemSortCondition.from(itemSortCondition);
 
+		// 요청한 조건에 해당하는 아이템 중 size 만큼 커서 아이디와 아이템 아이디를 가져옴
 		CursorSummary<ItemCursorSummary> itemCursorSummaryCursorSummary = itemCursorReader.readByCursor(
 			keyword,
 			parameters,
@@ -153,6 +154,7 @@ public class ItemService {
 			hobby
 		);
 
+		// 요청한 조건에 해당하는 모든 아이템의 수를 itemTotalCount에 저장
 		int itemTotalCount = itemReader.getItemTotalCountByKeyword(keyword, hobby);
 
 		return new ItemGetByCursorServiceResponse(

--- a/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
+++ b/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
 	ITEM_NOT_FOUND("ITEM_002", "요청한 아이템은 찾을 수 없습니다."),
 	ITEM_URL_ALREADY_EXIST("ITEM_003", "이미 존재하는 아이템 URL 입니다."),
 	ITEM_BAD_SORT_CONDITION("ITEM_004", "잘못된 아이템 정렬 조건 입니다."),
+	NOT_FOUND_WHILE_READING_ITEM_SUMMARY("ITEM_005", "ITEM_SUMMARY를 만들기 위한 정보를 찾을 수 없습니다."),
 
 	// REVIEW
 	REVIEW_NOT_FOUND("REVIEW_001", "해당하는 리뷰는 찾을 수 없습니다."),

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemCursorReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemCursorReader.java
@@ -1,7 +1,11 @@
 package com.programmers.lime.domains.item.implementation;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,9 +14,16 @@ import com.programmers.lime.common.cursor.CursorPageParameters;
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.common.cursor.CursorUtils;
 import com.programmers.lime.common.model.Hobby;
+import com.programmers.lime.domains.item.model.FavoriteInfoForItemSummary;
+import com.programmers.lime.domains.item.model.ItemCursorIdInfo;
 import com.programmers.lime.domains.item.model.ItemCursorSummary;
+import com.programmers.lime.domains.item.model.ItemInfoForItemSummary;
 import com.programmers.lime.domains.item.model.ItemSortCondition;
+import com.programmers.lime.domains.item.model.ItemSummary;
+import com.programmers.lime.domains.item.model.ReviewInfoForItemSummary;
 import com.programmers.lime.domains.item.repository.ItemRepository;
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,6 +43,7 @@ public class ItemCursorReader {
 	) {
 		String trimmedKeyword = keyword.trim();
 
+		// 비어 있는 키워드일 경우 빈 리스트 반환
 		if (trimmedKeyword.isEmpty()) {
 			return new CursorSummary<>(
 				null,
@@ -40,17 +52,87 @@ public class ItemCursorReader {
 			);
 		}
 
-		int pageSize = getPageSize(parameters);
-
-		List<ItemCursorSummary> itemCursorSummaries = itemRepository.findAllByCursor(
+		// 키워드에 해당하는 아이템 아이디와 커서 아이디를 가져옴
+		List<ItemCursorIdInfo> itemCursorIdInfos = itemRepository.getItemIdsByCursor(
 			trimmedKeyword,
 			parameters.cursorId(),
-			pageSize,
+			getPageSize(parameters),
 			itemSortCondition,
 			hobby
 		);
 
+		// 키워드에 해당하는 아이템 아이디와 커서 아이디를 이용하여 커서 아아이디를 포함하는 아이템 정보를 리시트로 가져옴
+		List<ItemCursorSummary> itemCursorSummaries = getItemCursorSummaries(itemCursorIdInfos);
+
+		// itemCursorSummaries는 아이템에 대한 정보와 아이템에 해당하는 커서 아이디를 가지고 있는 리스트
+		// 반환되는 CursorSummary<ItemCursorSummary> 객체는 다음 커서 아이디, 현재 페이지 아이템 개수, 요청한 사이즈 만큼의 아이템 정보를 가지고 있는 객체
 		return CursorUtils.getCursorSummaries(itemCursorSummaries);
+	}
+
+	private List<ItemCursorSummary> getItemCursorSummaries(final List<ItemCursorIdInfo> itemCursorIdInfos) {
+
+		// 아이템 아이디 리스트를 가져옴
+		List<Long> itemIds = itemCursorIdInfos.stream()
+			.map(ItemCursorIdInfo::itemId)
+			.toList();
+
+		// 아이템 아이디를 이용하여 아이템 정보를 가져옴
+		List<ItemSummary> itemSummaries = getItemSummaries(itemIds);
+
+		// 커서 아이디를 포함 시켜서 아이템 정보를 저장한 ItemCursorSummary 리스트를 생성
+		List<ItemCursorSummary> itemCursorSummaries = new ArrayList<>();
+		for(int i = 0; i< itemCursorIdInfos.size(); i++) {
+			ItemCursorIdInfo itemCursorIdInfo = itemCursorIdInfos.get(i);
+			ItemSummary itemSummary = itemSummaries.get(i);
+
+			ItemCursorSummary itemCursorSummary = new ItemCursorSummary(
+				itemCursorIdInfo.cursorId(),
+				itemSummary
+			);
+
+			itemCursorSummaries.add(itemCursorSummary);
+		}
+
+		return itemCursorSummaries;
+	}
+
+	private List<ItemSummary> getItemSummaries(final List<Long> itemIds) {
+
+		Map<Long, ItemInfoForItemSummary> itemInfoMap  = itemRepository.getItemInfosByItemIds(itemIds)
+			.stream()
+			.collect(Collectors.toMap(ItemInfoForItemSummary::id, Function.identity()));
+
+		Map<Long, ReviewInfoForItemSummary> reviewInfoMap  = itemRepository.getReviewInfosByItemIds(itemIds)
+			.stream()
+			.collect(Collectors.toMap(ReviewInfoForItemSummary::itemId, Function.identity()));
+
+		Map<Long, FavoriteInfoForItemSummary> favoriteInfoMap  = itemRepository.getFavoriteInfosByItemIds(itemIds)
+			.stream()
+			.collect(Collectors.toMap(FavoriteInfoForItemSummary::itemId, Function.identity()));
+
+
+		return itemIds.stream().map(itemId -> {
+
+			if (!itemInfoMap.containsKey(itemId) ||
+				!reviewInfoMap.containsKey(itemId) ||
+				!favoriteInfoMap.containsKey(itemId)
+			) {
+				throw new BusinessException(ErrorCode.NOT_FOUND_WHILE_READING_ITEM_SUMMARY);
+			}
+
+			ItemInfoForItemSummary itemInfo = itemInfoMap.get(itemId);
+			ReviewInfoForItemSummary reviewInfo = reviewInfoMap.get(itemId);
+			FavoriteInfoForItemSummary favoriteInfo = favoriteInfoMap.get(itemId);
+
+			return ItemSummary.builder()
+				.id(itemInfo.id())
+				.name(itemInfo.name())
+				.price(itemInfo.price())
+				.image(itemInfo.image())
+				.reviewCount(reviewInfo.reviewCount())
+				.favoriteCount(favoriteInfo.favoriteCount())
+				.build();
+		}).toList();
 	}
 
 	private int getPageSize(final CursorPageParameters parameters) {

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/FavoriteInfoForItemSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/FavoriteInfoForItemSummary.java
@@ -1,0 +1,7 @@
+package com.programmers.lime.domains.item.model;
+
+public record FavoriteInfoForItemSummary(
+	Long itemId,
+	Long favoriteCount
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemCursorIdInfo.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemCursorIdInfo.java
@@ -1,0 +1,7 @@
+package com.programmers.lime.domains.item.model;
+
+public record ItemCursorIdInfo(
+	Long itemId,
+	String cursorId
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemInfoForItemSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemInfoForItemSummary.java
@@ -1,0 +1,15 @@
+package com.programmers.lime.domains.item.model;
+
+import lombok.Builder;
+
+@Builder
+public record ItemInfoForItemSummary(
+	Long id,
+
+	String name,
+
+	Integer price,
+
+	String image
+)  {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ItemSummary.java
@@ -14,6 +14,10 @@ public record ItemSummary(
 
 	String image,
 
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+
+	Long reviewCount,
+
+	Long favoriteCount
 ) {
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ReviewInfoForItemSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/ReviewInfoForItemSummary.java
@@ -1,0 +1,7 @@
+package com.programmers.lime.domains.item.model;
+
+public record ReviewInfoForItemSummary(
+	Long itemId,
+	Long reviewCount
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursor.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursor.java
@@ -4,17 +4,26 @@ import java.util.List;
 
 import com.programmers.lime.common.model.Hobby;
 import com.programmers.lime.domains.inventory.model.InventoryReviewItemSummary;
-import com.programmers.lime.domains.item.model.ItemCursorSummary;
+import com.programmers.lime.domains.item.model.FavoriteInfoForItemSummary;
+import com.programmers.lime.domains.item.model.ItemCursorIdInfo;
+import com.programmers.lime.domains.item.model.ItemInfoForItemSummary;
 import com.programmers.lime.domains.item.model.ItemSortCondition;
+import com.programmers.lime.domains.item.model.ReviewInfoForItemSummary;
 
 public interface ItemRepositoryForCursor {
-	List<ItemCursorSummary> findAllByCursor(
+	List<ItemCursorIdInfo> getItemIdsByCursor(
 		final String keyword,
 		final String cursorId,
 		final int pageSize,
 		final ItemSortCondition itemSortCondition,
 		final Hobby hobby
 	);
+
+	List<ItemInfoForItemSummary> getItemInfosByItemIds(List<Long> itemIds);
+
+	List<ReviewInfoForItemSummary> getReviewInfosByItemIds(List<Long> itemIds);
+
+	List<FavoriteInfoForItemSummary> getFavoriteInfosByItemIds(List<Long> itemIds);
 
 	List<InventoryReviewItemSummary> findReviewedItemByCursor(
 		final List<Long> itemIdsFromReview,

--- a/lime-domain/src/test/java/com/programmers/lime/domains/item/implementation/ItemCursorReaderTest.java
+++ b/lime-domain/src/test/java/com/programmers/lime/domains/item/implementation/ItemCursorReaderTest.java
@@ -16,8 +16,16 @@ import com.programmers.lime.common.cursor.CursorPageParameters;
 import com.programmers.lime.common.cursor.CursorPageParametersBuilder;
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.common.cursor.CursorUtils;
+import com.programmers.lime.domains.item.model.FavoriteInfoForItemSummary;
+import com.programmers.lime.domains.item.model.FavoriteInfoForItemSummaryBuilder;
+import com.programmers.lime.domains.item.model.ItemCursorIdInfo;
+import com.programmers.lime.domains.item.model.ItemCursorIdInfoBuilder;
 import com.programmers.lime.domains.item.model.ItemCursorSummary;
 import com.programmers.lime.domains.item.model.ItemCursorSummaryBuilder;
+import com.programmers.lime.domains.item.model.ItemInfoForItemSummary;
+import com.programmers.lime.domains.item.model.ItemInfoForItemSummaryBuilder;
+import com.programmers.lime.domains.item.model.ReviewInfoForItemSummary;
+import com.programmers.lime.domains.item.model.ReviewInfoForItemSummaryBuilder;
 import com.programmers.lime.domains.item.repository.ItemRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,23 +43,38 @@ class ItemCursorReaderTest {
 		// given
 		String keyword = " 농구 ";
 		CursorPageParameters parameters = CursorPageParametersBuilder.build();
-		List<ItemCursorSummary> itemCursorSummaries = ItemCursorSummaryBuilder.buildMany();
+		List<ItemCursorIdInfo> itemCursorIdInfos = ItemCursorIdInfoBuilder.buildMany();
+		List<Long> itemIds = itemCursorIdInfos.stream().map(ItemCursorIdInfo::itemId).toList();
+
+		List<ItemCursorSummary> itemCursorSummaries = ItemCursorSummaryBuilder.buildMany(itemIds);
 		CursorSummary<ItemCursorSummary> expectedCursorSummary = CursorUtils.getCursorSummaries(itemCursorSummaries);
 
-		given(itemRepository.findAllByCursor(
+		List<ItemInfoForItemSummary> itemInfos = ItemInfoForItemSummaryBuilder.buildMany(itemIds);
+		List<FavoriteInfoForItemSummary> favoriteInfoForItemSummaries = FavoriteInfoForItemSummaryBuilder.buildMany(itemIds);
+		List<ReviewInfoForItemSummary> reviewInfoForItemSummaries = ReviewInfoForItemSummaryBuilder.buildMany(itemIds);
+
+		given(itemRepository.getItemIdsByCursor(
 				keyword.trim(),
 				parameters.cursorId(),
-				parameters.size()
+				parameters.size(),
+				null,
+				null
 			)
-		).willReturn(itemCursorSummaries);
+		).willReturn(itemCursorIdInfos);
+
+		given(itemRepository.getItemInfosByItemIds(itemIds)).willReturn(itemInfos);
+		given(itemRepository.getFavoriteInfosByItemIds(itemIds)).willReturn(favoriteInfoForItemSummaries);
+		given(itemRepository.getReviewInfosByItemIds(itemIds)).willReturn(reviewInfoForItemSummaries);
 
 		// when
 		CursorSummary<ItemCursorSummary> actualCursorSummary = itemCursorReader.readByCursor(
 			keyword,
-			parameters
+			parameters,
+			null,
+			null
 		);
 
-		// then
+		//then
 		assertThat(actualCursorSummary)
 			.usingRecursiveComparison()
 			.isEqualTo(expectedCursorSummary);

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/common/cursor/CursorIdBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/common/cursor/CursorIdBuilder.java
@@ -1,0 +1,12 @@
+package com.programmers.lime.common.cursor;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CursorIdBuilder {
+
+	public static String build(Long id) {
+		return "202301010000000000000" + id;
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/FavoriteInfoForItemSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/FavoriteInfoForItemSummaryBuilder.java
@@ -1,0 +1,20 @@
+package com.programmers.lime.domains.item.model;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FavoriteInfoForItemSummaryBuilder {
+
+	public static FavoriteInfoForItemSummary build(Long itemId, Long favoriteCount) {
+		return new FavoriteInfoForItemSummary(itemId, favoriteCount);
+	}
+
+	public static List<FavoriteInfoForItemSummary> buildMany(List<Long> ids) {
+		return ids.stream().map(
+			id -> build(id, id)
+		).toList();
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemCursorIdInfoBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemCursorIdInfoBuilder.java
@@ -1,0 +1,24 @@
+package com.programmers.lime.domains.item.model;
+
+import java.util.List;
+
+import com.programmers.lime.common.cursor.CursorIdBuilder;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ItemCursorIdInfoBuilder {
+
+	public static List<ItemCursorIdInfo> buildMany() {
+		return List.of(
+			build(1L),
+			build(2L),
+			build(3L)
+		);
+	}
+
+	public static ItemCursorIdInfo build(Long id) {
+		return new ItemCursorIdInfo(id, CursorIdBuilder.build(id));
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemCursorSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemCursorSummaryBuilder.java
@@ -1,7 +1,8 @@
 package com.programmers.lime.domains.item.model;
 
 import java.util.List;
-import java.util.stream.LongStream;
+
+import com.programmers.lime.common.cursor.CursorIdBuilder;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -11,14 +12,14 @@ public class ItemCursorSummaryBuilder {
 
 	public static ItemCursorSummary build(final Long id) {
 		return new ItemCursorSummary(
-			"202301010000000000000" + id,
+			CursorIdBuilder.build(id),
 			ItemSummaryBuilder.build(id)
 		);
 	}
 
-	public static List<ItemCursorSummary> buildMany() {
-		return LongStream.range(1, 11)
-			.mapToObj(ItemCursorSummaryBuilder::build)
-			.toList();
+	public static List<ItemCursorSummary> buildMany(List<Long> ids) {
+		return ids.stream().map(
+			ItemCursorSummaryBuilder::build
+		).toList();
 	}
 }

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemInfoForItemSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemInfoForItemSummaryBuilder.java
@@ -1,0 +1,30 @@
+package com.programmers.lime.domains.item.model;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ItemInfoForItemSummaryBuilder {
+
+	public static ItemInfoForItemSummary build(
+		final Long id,
+		final String name,
+		final Integer price,
+		final String image
+	) {
+		return ItemInfoForItemSummary.builder()
+			.id(id)
+			.name(name)
+			.price(price)
+			.image(image)
+			.build();
+	}
+
+	public static List<ItemInfoForItemSummary> buildMany(List<Long> ids) {
+		return ids.stream().map(
+			id -> build(id, "name" + id, id.intValue(), "image" + id)
+		).toList();
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ItemSummaryBuilder.java
@@ -1,7 +1,5 @@
 package com.programmers.lime.domains.item.model;
 
-import java.time.LocalDateTime;
-
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -11,10 +9,11 @@ public class ItemSummaryBuilder {
 	public static ItemSummary build(final Long id) {
 		return ItemSummary.builder()
 			.id(id)
-			.name("아이템")
-			.price(10000)
-			.image("https://www.naver.com//image")
-			.createdAt(LocalDateTime.of(2023, 1, 1, 0, 0, 0))
+			.name("name" + id)
+			.price(id.intValue())
+			.image("image" + id)
+			.favoriteCount(id)
+			.reviewCount(id)
 			.build();
 	}
 }

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ReviewInfoForItemSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/item/model/ReviewInfoForItemSummaryBuilder.java
@@ -1,0 +1,22 @@
+package com.programmers.lime.domains.item.model;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewInfoForItemSummaryBuilder {
+
+	public static ReviewInfoForItemSummary build(Long itemId, Long reviewCount) {
+		return new ReviewInfoForItemSummary(
+			itemId, reviewCount
+		);
+	}
+
+	public static List<ReviewInfoForItemSummary> buildMany(List<Long> ids) {
+		return ids.stream().map(
+			id -> build(id, id)
+		).toList();
+	}
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

아이템 목록 조회에 찜 개수, 리뷰 수 추가하였습니다. 😊❤ dc0163a4e7e82a6419e251308389c6a66b29d680

### Issue Number

[LIME-57]

### 기능 설명

#### 아이템 목록조회 할 때 찜 개수, 리뷰 수를 추가 기능 설명  😊❤
- 기존 아이템 목록조회에 찜 개수, 리뷰 수를 추가하기위해 MemberItem, Review 엔티티에 있는 정보를 가져와야 합니다.

#### 기존 목록조회에서 기능 추가할 때 문제점  😊❤
- 아이템 목록조회 하기 위해서 Item, MemberItem, Review 엔티티를 조인해야 합니다.
- 기존 방법으로 repository에서 이를 모두 해결 하였지만 그로 인해 N+1 문제 발생, repository에 의존적인 코드 작성 등의 문제가 있었습니다.
- N+1 문제도 해결 책은 있었지만 3개 이상의 테이블을 조인하게 되면 결국 N+1 문제가 발생하거나 코드가 너무 복잡해졌습니다.

#### 책임 분산으로 문제 해결하기  😊❤
- 이 문제를 해결하기 위해 where in을 활용한 서브쿼리를 이용하였습니다.
- repository에 아이템 데이터를 가져올 때 아이템 아이디와 커서 아이디를 포함하는 ItemCursorInfo 리스트를 가져 옵니다. (ItemCursorReader 클래스에 56번~62번 라인 참조 dc0163a4e7e82a6419e251308389c6a66b29d680) 
- repository에서는 입력받은 아이템 아이디를 이용하여 Item 엔티티와 각각의 엔티티와 join하여 데이터를 반환합니다. 
- ItemCursorInfo 리스트를 이용하여 ItemSummary 클래스를 만드는데 필요한 도메인과 각각 조인 합니다. (ItemCursorReader 클래스의 getItemSummaries 메서드 참조)
- 이를 통해 하나의 쿼리에 너무 많은 기능이 포함되지 않게 되고 다른 테이블에 데이터를 가져오거나 제외하기가 쉬워졌습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-57]: https://uju-lime.atlassian.net/browse/LIME-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ