### PR TITLE
[LIME-58] 리뷰 이미지 추가 

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/review/api/ReviewController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/review/api/ReviewController.java
@@ -1,5 +1,7 @@
 package com.programmers.lime.domains.review.api;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,7 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.programmers.lime.domains.review.api.dto.request.ReviewCreateRequest;
 import com.programmers.lime.domains.review.api.dto.request.ReviewUpdateRequest;
@@ -39,9 +43,10 @@ public class ReviewController {
 	@PostMapping()
 	public ResponseEntity<ReviewCreateResponse> createReview(
 		@PathVariable final Long itemId,
-		@Valid @RequestBody final ReviewCreateRequest request
+		@Valid @ModelAttribute final ReviewCreateRequest request,
+		@RequestPart(value = "multipartReviewImages", required = false) final List<MultipartFile> multipartReviewImages
 	) {
-		reviewService.createReview(itemId, request.toReviewContent());
+		reviewService.createReview(itemId, request.toReviewContent(), multipartReviewImages);
 		ReviewCreateResponse response = new ReviewCreateResponse(itemId);
 
 		return ResponseEntity.ok(response);

--- a/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
@@ -1,6 +1,14 @@
 package com.programmers.lime.domains.review.application;
 
+import java.util.UUID;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.programmers.lime.common.cursor.CursorPageParameters;
 import com.programmers.lime.common.cursor.CursorSummary;
@@ -15,14 +23,19 @@ import com.programmers.lime.domains.review.implementation.ReviewRemover;
 import com.programmers.lime.domains.review.implementation.ReviewStatistics;
 import com.programmers.lime.domains.review.model.ReviewContent;
 import com.programmers.lime.domains.review.model.ReviewCursorSummary;
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.ErrorCode;
 import com.programmers.lime.global.level.PayPoint;
 import com.programmers.lime.global.util.MemberUtils;
+import com.programmers.lime.s3.S3Manager;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
+
+	private static final String DIRECTORY = "review-images";
 
 	private final ReviewAppender reviewAppender;
 	private final ReviewModifier reviewModifier;
@@ -32,16 +45,36 @@ public class ReviewService {
 	private final ReviewStatistics reviewStatistics;
 	private final MemberUtils memberUtils;
 	private final ReviewReader reviewReader;
+	private final S3Manager s3Manager;
 
 	@PayPoint(15)
 	public Long createReview(
 		final Long itemId,
-		final ReviewContent reviewContent
+		final ReviewContent reviewContent,
+		final List<MultipartFile> multipartReviewImages
 	) {
+		List<String> reviewImageURLs = uploadReviewImages(multipartReviewImages);
+
 		Long memberId = memberUtils.getCurrentMemberId();
-		reviewAppender.append(itemId, memberId, reviewContent);
+		reviewAppender.append(itemId, memberId, reviewContent, reviewImageURLs);
 
 		return memberId;
+	}
+
+	private List<String> uploadReviewImages(final List<MultipartFile> multipartReviewImages) {
+		return multipartReviewImages.stream()
+			.map(multipartFile -> {
+				try {
+					String fileType = StringUtils.getFilenameExtension(multipartFile.getOriginalFilename());
+					String imageName = UUID.randomUUID() + fileType;
+					s3Manager.uploadFile(multipartFile, DIRECTORY, imageName);
+
+					return s3Manager.getUrl(DIRECTORY, imageName).toString();
+				} catch (IOException e) {
+					throw new BusinessException(ErrorCode.S3_UPLOAD_FAIL);
+				}
+			})
+			.collect(Collectors.toList());
 	}
 
 	public void updateReview(

--- a/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
+++ b/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 	INVALID_REQUEST_FILED_TYPE("COMMON_011", "잘못된 요청 필드 타입입니다."),
 	EXPIRED_REFRESH_TOKEN("COMMON_012", "Refresh Token이 만료되었습니다."),
 	INVALID_REFRESH_TOKEN("COMMON_013", "Refresh Token이 유효하지 않습니다."),
+	S3_UPLOAD_FAIL("COMMON_014", "S3 업로드에 실패했습니다."),
 
 	// Member
 	MEMBER_LOGIN_FAIL("MEMBER_001", "로그인 정보가 잘못 되었습니다."),

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/domain/ReviewImage.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/domain/ReviewImage.java
@@ -1,10 +1,14 @@
 package com.programmers.lime.domains.review.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -19,17 +23,18 @@ public class ReviewImage {
 	@Column(name = "id")
 	private Long id;
 
-	@Column(name = "review_id", nullable = false)
-	private Long reviewId;
+	@ManyToOne
+	@JoinColumn(name = "review_id", nullable = false)
+	private Review review;
 
 	@Column(name = "image_url", nullable = false)
 	private String imageUrl;
 
 	public ReviewImage(
-		final Long reviewId,
+		final Review review,
 		final String imageUrl
 	) {
-		this.reviewId = reviewId;
-		this.imageUrl = imageUrl;
+		this.review = Objects.requireNonNull(review);
+		this.imageUrl = Objects.requireNonNull(imageUrl);
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/domain/ReviewImage.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/domain/ReviewImage.java
@@ -1,0 +1,36 @@
+package com.programmers.lime.domains.review.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "review_images")
+public class ReviewImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@JoinColumn(name = "review_id", nullable = false)
+	private Long reviewId;
+
+	@Column(name = "image_url", nullable = false)
+	private String imageUrl;
+
+	public ReviewImage(
+		final Long reviewId,
+		final String imageUrl
+	) {
+		this.reviewId = reviewId;
+		this.imageUrl = imageUrl;
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/domain/ReviewImage.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/domain/ReviewImage.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -20,7 +19,7 @@ public class ReviewImage {
 	@Column(name = "id")
 	private Long id;
 
-	@JoinColumn(name = "review_id", nullable = false)
+	@Column(name = "review_id", nullable = false)
 	private Long reviewId;
 
 	@Column(name = "image_url", nullable = false)

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewAppender.java
@@ -1,5 +1,7 @@
 package com.programmers.lime.domains.review.implementation;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.programmers.lime.domains.review.domain.Review;
@@ -14,13 +16,18 @@ public class ReviewAppender {
 
 	private final ReviewRepository reviewRepository;
 
+	private final ReviewImageAppender reviewImageAppender;
+
 	public Long append(
 		final Long itemId,
 		final Long memberId,
-		final ReviewContent reviewContent
+		final ReviewContent reviewContent,
+		final List<String> reviewImageURLs
 	) {
 		Review review = getReview(memberId, reviewContent, itemId);
-		reviewRepository.save(review);
+		Review savedReview = reviewRepository.save(review);
+
+		reviewImageAppender.append(savedReview.getId(), reviewImageURLs);
 
 		return review.getId();
 	}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewCursorReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewCursorReader.java
@@ -1,13 +1,20 @@
 package com.programmers.lime.domains.review.implementation;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
 import com.programmers.lime.common.cursor.CursorPageParameters;
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.common.cursor.CursorUtils;
+import com.programmers.lime.domains.member.model.MemberInfo;
+import com.programmers.lime.domains.review.model.MemberInfoWithReviewId;
+import com.programmers.lime.domains.review.model.ReviewCursorIdInfo;
 import com.programmers.lime.domains.review.model.ReviewCursorSummary;
+import com.programmers.lime.domains.review.model.ReviewSummary;
 import com.programmers.lime.domains.review.repository.ReviewRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,14 +34,52 @@ public class ReviewCursorReader {
 	) {
 		int pageSize = getPageSize(parameters);
 
-		List<ReviewCursorSummary> reviewCursorSummaries = reviewRepository.findAllByCursor(
+		List<ReviewCursorIdInfo> reviewCursorIdInfos = reviewRepository.findAllByCursor(
 			itemId,
-			memberId,
 			parameters.cursorId(),
 			pageSize
 		);
 
+		List<ReviewCursorSummary> reviewCursorSummaries = getReviewCursorSummaries(reviewCursorIdInfos, memberId);
+
 		return CursorUtils.getCursorSummaries(reviewCursorSummaries);
+	}
+
+	private List<ReviewCursorSummary> getReviewCursorSummaries(
+		final List<ReviewCursorIdInfo> reviewCursorIdInfos,
+		final Long memberId
+	) {
+
+		// 리뷰 아이디 리스트를 가져옴
+		List<Long> reviewIds = reviewCursorIdInfos.stream()
+			.map(ReviewCursorIdInfo::reviewId)
+			.toList();
+
+		// 리뷰 아이디를 이용하여 리뷰 정보를 가져옴
+		Map<Long, ReviewSummary> reviewSummaryMap = reviewRepository.getReviewSummaries(reviewIds)
+			.stream()
+			.collect(Collectors.toMap(ReviewSummary::reviewId, Function.identity()));
+
+		// 리뷰 아이디를 이용하여 멤버 정보를 가져옴
+		Map<Long, MemberInfoWithReviewId> memberInfoMap = reviewRepository.getMemberInfos(reviewIds)
+			.stream()
+			.collect(Collectors.toMap(MemberInfoWithReviewId::reviewId, Function.identity()));
+
+
+		return reviewCursorIdInfos.stream()
+			.map(reviewCursorIdInfo -> {
+				ReviewSummary reviewSummary = reviewSummaryMap.get(reviewCursorIdInfo.reviewId());
+				MemberInfoWithReviewId memberInfoWithReviewId = memberInfoMap.get(reviewCursorIdInfo.reviewId());
+				MemberInfo memberInfo = memberInfoWithReviewId.memberInfo();
+
+				return ReviewCursorSummary.builder()
+					.cursorId(reviewCursorIdInfo.cursorId())
+					.reviewSummary(reviewSummary)
+					.memberInfo(memberInfoWithReviewId.memberInfo())
+					.isReviewed(memberInfo.memberId().equals(memberId))
+					.build();
+			})
+			.toList();
 	}
 
 	private int getPageSize(final CursorPageParameters parameters) {

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewImageAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewImageAppender.java
@@ -1,0 +1,28 @@
+package com.programmers.lime.domains.review.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.review.domain.ReviewImage;
+import com.programmers.lime.domains.review.repository.ReviewImageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewImageAppender {
+
+	private final ReviewImageRepository reviewImageRepository;
+
+	public void append(
+		final Long reviewId,
+		final List<String> imageUrls
+	) {
+		List<ReviewImage> reviewImages = imageUrls.stream()
+			.map(imageUrl -> new ReviewImage(reviewId, imageUrl))
+			.toList();
+
+		reviewImageRepository.saveAll(reviewImages);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewImageAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewImageAppender.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.programmers.lime.domains.review.domain.Review;
 import com.programmers.lime.domains.review.domain.ReviewImage;
 import com.programmers.lime.domains.review.repository.ReviewImageRepository;
 
@@ -15,12 +16,16 @@ public class ReviewImageAppender {
 
 	private final ReviewImageRepository reviewImageRepository;
 
+	private final ReviewReader reviewReader;
+
 	public void append(
 		final Long reviewId,
 		final List<String> imageUrls
 	) {
+		Review review = reviewReader.read(reviewId);
+
 		List<ReviewImage> reviewImages = imageUrls.stream()
-			.map(imageUrl -> new ReviewImage(reviewId, imageUrl))
+			.map(imageUrl -> new ReviewImage(review, imageUrl))
 			.toList();
 
 		reviewImageRepository.saveAll(reviewImages);

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/model/MemberInfoWithReviewId.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/model/MemberInfoWithReviewId.java
@@ -1,0 +1,9 @@
+package com.programmers.lime.domains.review.model;
+
+import com.programmers.lime.domains.member.model.MemberInfo;
+
+public record MemberInfoWithReviewId(
+	Long reviewId,
+	MemberInfo memberInfo
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewCursorIdInfo.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewCursorIdInfo.java
@@ -1,0 +1,7 @@
+package com.programmers.lime.domains.review.model;
+
+public record ReviewCursorIdInfo(
+	Long reviewId,
+	String cursorId
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewCursorSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewCursorSummary.java
@@ -1,7 +1,5 @@
 package com.programmers.lime.domains.review.model;
 
-import java.time.LocalDateTime;
-
 import com.programmers.lime.common.cursor.CursorIdParser;
 import com.programmers.lime.domains.member.model.MemberInfo;
 
@@ -13,16 +11,8 @@ public record ReviewCursorSummary(
 
 	MemberInfo memberInfo,
 
-	Long reviewId,
+	ReviewSummary reviewSummary,
 
-	int rate,
-
-	String content,
-
-	boolean isReviewed,
-
-	LocalDateTime createdAt,
-
-	LocalDateTime updatedAt
-) implements CursorIdParser {
+	boolean isReviewed
+	) implements CursorIdParser {
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewSummary.java
@@ -3,6 +3,9 @@ package com.programmers.lime.domains.review.model;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import lombok.Builder;
+
+@Builder
 public record ReviewSummary(
 
 	Long reviewId,

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewSummary.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewSummary.java
@@ -1,0 +1,20 @@
+package com.programmers.lime.domains.review.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReviewSummary(
+
+	Long reviewId,
+
+	int rate,
+
+	String content,
+
+	List<String> imageUrls,
+
+	LocalDateTime createdAt,
+
+	LocalDateTime updatedAt
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewImageRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewImageRepository.java
@@ -1,0 +1,8 @@
+package com.programmers.lime.domains.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.programmers.lime.domains.review.domain.ReviewImage;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursor.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursor.java
@@ -2,15 +2,20 @@ package com.programmers.lime.domains.review.repository;
 
 import java.util.List;
 
-import com.programmers.lime.domains.review.model.ReviewCursorSummary;
+import com.programmers.lime.domains.review.model.MemberInfoWithReviewId;
+import com.programmers.lime.domains.review.model.ReviewCursorIdInfo;
+import com.programmers.lime.domains.review.model.ReviewSummary;
 
 public interface ReviewRepositoryForCursor {
-	List<ReviewCursorSummary> findAllByCursor(
+	List<ReviewCursorIdInfo> findAllByCursor(
 		Long itemId,
-		Long memberId,
 		String cursorId,
 		int pageSize
 	);
+
+	List<MemberInfoWithReviewId> getMemberInfos(List<Long> reviewIds);
+
+	List<ReviewSummary> getReviewSummaries(List<Long> reviewIds);
 
 	int getReviewCount(Long itemId);
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursorImpl.java
@@ -84,7 +84,7 @@ public class ReviewRepositoryForCursorImpl implements ReviewRepositoryForCursor 
 			)
 			.from(review)
 			.where(review.id.in(reviewIds))
-			.leftJoin(reviewImage).on(review.id.eq(reviewImage.reviewId))
+			.leftJoin(reviewImage).on(review.eq(reviewImage.review))
 			.transform(
 				groupBy(review.id)
 					.list(

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursorImpl.java
@@ -2,12 +2,16 @@ package com.programmers.lime.domains.review.repository;
 
 import static com.programmers.lime.domains.member.domain.QMember.*;
 import static com.programmers.lime.domains.review.domain.QReview.*;
+import static com.programmers.lime.domains.review.domain.QReviewImage.*;
+import static com.querydsl.core.group.GroupBy.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.programmers.lime.domains.member.model.MemberInfo;
-import com.programmers.lime.domains.review.model.ReviewCursorSummary;
+import com.programmers.lime.domains.review.model.MemberInfoWithReviewId;
+import com.programmers.lime.domains.review.model.ReviewCursorIdInfo;
+import com.programmers.lime.domains.review.model.ReviewSummary;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -27,34 +31,20 @@ public class ReviewRepositoryForCursorImpl implements ReviewRepositoryForCursor 
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<ReviewCursorSummary> findAllByCursor(
+	public List<ReviewCursorIdInfo> findAllByCursor(
 		final Long itemId,
-		final Long memberId,
 		final String cursorId,
 		final int pageSize
 	) {
 		return jpaQueryFactory
 			.select(
 				Projections.constructor(
-					ReviewCursorSummary.class,
-					generateCursorId(),
-					Projections.constructor(
-						MemberInfo.class,
-						member.id,
-						member.nickname.nickname,
-						member.socialInfo.profileImage,
-						member.levelPoint
-					),
+					ReviewCursorIdInfo.class,
 					review.id,
-					review.rating,
-					review.content,
-					memberIdCondition(memberId),
-					review.createdAt,
-					review.modifiedAt
+					generateCursorId()
 				)
 			)
 			.from(review)
-			.join(member).on(review.memberId.eq(member.id))
 			.where(
 				cursorIdCondition(cursorId),
 				review.itemId.eq(itemId)
@@ -62,6 +52,55 @@ public class ReviewRepositoryForCursorImpl implements ReviewRepositoryForCursor 
 			.limit(pageSize)
 			.orderBy(decrease(), review.id.desc())
 			.fetch();
+	}
+
+	@Override
+	public List<MemberInfoWithReviewId> getMemberInfos(final List<Long> reviewIds) {
+		return jpaQueryFactory
+			.select(
+				Projections.constructor(
+					MemberInfoWithReviewId.class,
+					review.id,
+					Projections.constructor(
+						MemberInfo.class,
+						member.id,
+						member.nickname.nickname,
+						member.socialInfo.profileImage,
+						member.levelPoint
+					)
+				)
+			)
+			.from(review)
+			.where(review.id.in(reviewIds))
+			.leftJoin(member).on(review.memberId.eq(member.id))
+			.fetch();
+	}
+
+	@Override
+	public List<ReviewSummary> getReviewSummaries(final List<Long> reviewIds) {
+		return jpaQueryFactory
+			.select(
+				review
+			)
+			.from(review)
+			.where(review.id.in(reviewIds))
+			.leftJoin(reviewImage).on(review.id.eq(reviewImage.reviewId))
+			.transform(
+				groupBy(review.id)
+					.list(
+						Projections.constructor(
+							ReviewSummary.class,
+							review.id,
+							review.rating,
+							review.content,
+							list(
+								reviewImage.imageUrl
+							),
+							review.createdAt,
+							review.modifiedAt
+						)
+					)
+			);
 	}
 
 	@Override
@@ -76,15 +115,6 @@ public class ReviewRepositoryForCursorImpl implements ReviewRepositoryForCursor 
 
 	private OrderSpecifier<LocalDateTime> decrease() {
 		return new OrderSpecifier<>(Order.DESC, review.createdAt);
-	}
-
-	private BooleanExpression memberIdCondition(final Long memberId) {
-		if (memberId == null) {
-			// memberId가 null인 경우(사용자가 로그인 하지 않은 경우) false 반환
-			return Expressions.asBoolean(false).isTrue();
-		}
-
-		return review.memberId.eq(memberId);
 	}
 
 	private BooleanExpression cursorIdCondition(final String cursorId) {

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/MemberInfoBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/MemberInfoBuilder.java
@@ -1,0 +1,19 @@
+package com.programmers.lime.domains.member.domain;
+
+import com.programmers.lime.domains.member.model.MemberInfo;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberInfoBuilder {
+
+	public static MemberInfo build(final Long id) {
+		return MemberInfo.builder()
+			.memberId(id)
+			.nickname("nickname" + id)
+			.profileImage("profileImage" + id)
+			.level(id.intValue())
+			.build();
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/MemberInfoWithReviewIdBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/MemberInfoWithReviewIdBuilder.java
@@ -1,0 +1,24 @@
+package com.programmers.lime.domains.member.domain;
+
+import java.util.List;
+
+import com.programmers.lime.domains.review.model.MemberInfoWithReviewId;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberInfoWithReviewIdBuilder {
+
+	public static MemberInfoWithReviewId build(final Long id) {
+		return new MemberInfoWithReviewId(
+			id,
+			MemberInfoBuilder.build(id)
+		);
+	}
+	public static List<MemberInfoWithReviewId> buildMany(List<Long> ids) {
+		return ids.stream()
+			.map(MemberInfoWithReviewIdBuilder::build)
+			.toList();
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/review/ReviewCursorIdInfoBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/review/ReviewCursorIdInfoBuilder.java
@@ -1,0 +1,23 @@
+package com.programmers.lime.domains.review;
+
+import java.util.List;
+
+import com.programmers.lime.domains.review.model.ReviewCursorIdInfo;
+
+public class ReviewCursorIdInfoBuilder {
+
+	public static ReviewCursorIdInfo build(final Long id) {
+		return new ReviewCursorIdInfo(
+			id,
+			"202301010000000000000" + id
+		);
+	}
+
+	public static List<ReviewCursorIdInfo> buildMany() {
+		return List.of(
+			build(1L),
+			build(2L),
+			build(3L)
+		);
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/review/ReviewCursorSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/review/ReviewCursorSummaryBuilder.java
@@ -3,6 +3,7 @@ package com.programmers.lime.domains.review;
 import java.util.List;
 import java.util.stream.LongStream;
 
+import com.programmers.lime.domains.member.domain.MemberInfoBuilder;
 import com.programmers.lime.domains.review.model.ReviewCursorSummary;
 
 import lombok.AccessLevel;
@@ -14,15 +15,15 @@ public class ReviewCursorSummaryBuilder {
 	public static ReviewCursorSummary build(final Long reviewId) {
 		return ReviewCursorSummary.builder()
 			.cursorId("202301010000000000000" + reviewId)
-			.reviewId(reviewId)
-			.rate(1)
-			.content("content")
+			.reviewSummary(ReviewSummaryBuilder.build(reviewId))
+			.memberInfo(MemberInfoBuilder.build(reviewId))
+			.isReviewed(false)
 			.build();
 	}
 
-	public static List<ReviewCursorSummary> buildMany() {
-		return LongStream.range(1, 11)
-			.mapToObj(ReviewCursorSummaryBuilder::build)
+	public static List<ReviewCursorSummary> buildMany(final List<Long> reviewIds) {
+		return reviewIds.stream()
+			.map(ReviewCursorSummaryBuilder::build)
 			.toList();
 	}
 }

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/review/ReviewSummaryBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/review/ReviewSummaryBuilder.java
@@ -1,0 +1,26 @@
+package com.programmers.lime.domains.review;
+
+import java.util.List;
+
+import com.programmers.lime.domains.review.model.ReviewSummary;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewSummaryBuilder {
+
+	public static ReviewSummary build(final Long reviewId) {
+		return ReviewSummary.builder()
+			.rate(reviewId.intValue() % 5 + 1)
+			.content("content" + reviewId)
+			.reviewId(reviewId)
+			.build();
+	}
+
+	public static List<ReviewSummary> buildMany(final List<Long> reviewIds) {
+		return reviewIds.stream()
+			.map(ReviewSummaryBuilder::build)
+			.toList();
+	}
+}

--- a/lime-infrastructure/src/main/java/com/programmers/lime/s3/S3Manager.java
+++ b/lime-infrastructure/src/main/java/com/programmers/lime/s3/S3Manager.java
@@ -3,6 +3,7 @@ package com.programmers.lime.s3;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -43,11 +44,10 @@ public class S3Manager {
 		final String directory,
 		final String fileName
 	) {
-		final String fileNameWithDir = directory + "/" + fileName;
+		final String fileNameWithDir = getFileNameWithDir(directory, fileName);
 		putS3(uploadFile, fileNameWithDir);
 		removeNewFile(uploadFile);
 	}
-
 	private void putS3(
 		final File uploadFile,
 		final String fileName
@@ -80,7 +80,16 @@ public class S3Manager {
 		final String directory,
 		final String fileName
 	) {
-		final String fileNameWithDir = directory + "/" + fileName;
+		final String fileNameWithDir = getFileNameWithDir(directory, fileName);
 		amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileNameWithDir));
+	}
+
+	public URL getUrl(String directory, String fileName) {
+		String fileNameWithDir = getFileNameWithDir(directory, fileName);
+		return amazonS3.getUrl(bucket, fileNameWithDir);
+	}
+
+	private String getFileNameWithDir(final String directory, final String fileName) {
+		return directory + "/" + fileName;
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
리뷰 이미지 관련 기능 추가 ❤❤
- 리뷰 등록할 때 이미지 여러개 넣을 수 있도록 기능 추가 92665c7d7ef09c7cb472d3d4f3c55207da2247ad
- 리뷰 조회할 때 이미지 조회할 수 있도록 기능 추가 8650439f504817455088b326dcde965b4b71f45d

### Issue Number

[LIME-58]

### 기능 설명

#### 리뷰 사진 저장 ❤❤
- 프론트에서 form-data로 Multipartfile을 전송 받으면 서버에서 네이버 클라우드 버킷으로 전송합니다.
- 이 후 네이버 클라우드에 저장되어있는 이미지의 주소를 리뷰 이미지 테이블에 리뷰 아이디를 pk로 하여 저장합니다. 632131ed8b8c5f4c21f5b5b12a783e6487a588c8 92665c7d7ef09c7cb472d3d4f3c55207da2247ad

#### 리뷰 목록 조회 ❤❤
- https://github.com/uju-in/lime-backend/pull/24 책임 분산 부분에서 설명한 것과 같이 리뷰 목록 조회도 where in 서브쿼리를 활용하여 이미지 주소 조회 기능을 추가하였습니다.


## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-58]: https://uju-lime.atlassian.net/browse/LIME-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ