### PR TITLE
[LIME-66]  리뷰 목록 조회 정렬 조건 추가 

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/review/api/ReviewController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/review/api/ReviewController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,11 +70,13 @@ public class ReviewController {
 	@GetMapping()
 	public ResponseEntity<ReviewGetByCursorResponse> getReviewsByCursor(
 		@PathVariable final Long itemId,
-		@ModelAttribute("request") @Valid final CursorRequest request
+		@ModelAttribute("request") @Valid final CursorRequest request,
+		@RequestParam(required = false) final String reviewSortCondition
 	) {
 		ReviewGetByCursorServiceResponse serviceResponse = reviewService.getReviewsByCursor(
 			itemId,
-			request.toParameters()
+			request.toParameters(),
+			reviewSortCondition
 		);
 
 		ReviewGetByCursorResponse response = ReviewGetByCursorResponse.from(serviceResponse);

--- a/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
@@ -23,6 +23,7 @@ import com.programmers.lime.domains.review.implementation.ReviewRemover;
 import com.programmers.lime.domains.review.implementation.ReviewStatistics;
 import com.programmers.lime.domains.review.model.ReviewContent;
 import com.programmers.lime.domains.review.model.ReviewCursorSummary;
+import com.programmers.lime.domains.review.model.ReviewSortCondition;
 import com.programmers.lime.error.BusinessException;
 import com.programmers.lime.error.ErrorCode;
 import com.programmers.lime.global.level.PayPoint;
@@ -90,14 +91,17 @@ public class ReviewService {
 
 	public ReviewGetByCursorServiceResponse getReviewsByCursor(
 		final Long itemId,
-		final CursorPageParameters parameters
+		final CursorPageParameters parameters,
+		final String reviewSortCondition
 	) {
+		ReviewSortCondition sortCondition = ReviewSortCondition.from(reviewSortCondition);
 		int reviewCount = reviewStatistics.getReviewCount(itemId);
 		Long memberId = memberUtils.getCurrentMemberId();
 		CursorSummary<ReviewCursorSummary> cursorSummary = reviewCursorReader.readByCursor(
 			itemId,
 			memberId,
-			parameters
+			parameters,
+			sortCondition
 		);
 
 		return new ReviewGetByCursorServiceResponse(reviewCount, cursorSummary);

--- a/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
+++ b/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 	REVIEW_NOT_FOUND("REVIEW_001", "해당하는 리뷰는 찾을 수 없습니다."),
 	REVIEW_NOT_EQUAL_ITEM("REVIEW_002", "리뷰 아이디와 아이템 아이디가 일치하지 않습니다."),
 	REVIEW_NOT_MINE("REVIEW_003", "리뷰 작성자와 로그인한 회원아이디가 일치하지 않습니다."),
+	REVIEW_BAD_SORT_CONDITION("REVIEW_004", "잘못된 리뷰 정렬 조건 입니다."),
 
 	// Vote
 	VOTE_NOT_FOUND("VOTE_001", "투표를 찾을 수 없습니다."),

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewCursorReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewCursorReader.java
@@ -14,6 +14,7 @@ import com.programmers.lime.domains.member.model.MemberInfo;
 import com.programmers.lime.domains.review.model.MemberInfoWithReviewId;
 import com.programmers.lime.domains.review.model.ReviewCursorIdInfo;
 import com.programmers.lime.domains.review.model.ReviewCursorSummary;
+import com.programmers.lime.domains.review.model.ReviewSortCondition;
 import com.programmers.lime.domains.review.model.ReviewSummary;
 import com.programmers.lime.domains.review.repository.ReviewRepository;
 
@@ -30,14 +31,16 @@ public class ReviewCursorReader {
 	public CursorSummary<ReviewCursorSummary> readByCursor(
 		final Long itemId,
 		final Long memberId,
-		final CursorPageParameters parameters
+		final CursorPageParameters parameters,
+		final ReviewSortCondition sortCondition
 	) {
 		int pageSize = getPageSize(parameters);
 
 		List<ReviewCursorIdInfo> reviewCursorIdInfos = reviewRepository.findAllByCursor(
 			itemId,
 			parameters.cursorId(),
-			pageSize
+			pageSize,
+			sortCondition
 		);
 
 		List<ReviewCursorSummary> reviewCursorSummaries = getReviewCursorSummaries(reviewCursorIdInfos, memberId);

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewSortCondition.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/model/ReviewSortCondition.java
@@ -1,0 +1,38 @@
+package com.programmers.lime.domains.review.model;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.ErrorCode;
+
+public enum ReviewSortCondition {
+	NEWEST,
+	LOWEST_RATE,
+	HIGHEST_RATE,
+	LIKE_COUNT_DESC;
+
+	private static final Map<String, ReviewSortCondition> SORT_CONDITION_MAP;
+
+	static {
+		SORT_CONDITION_MAP = Collections.unmodifiableMap(
+			Stream.of(ReviewSortCondition.values())
+				.collect(Collectors.toMap(ReviewSortCondition::name, Function.identity()))
+		);
+	}
+
+	public static ReviewSortCondition from(String sortCondition) {
+		if (sortCondition == null) {
+			return null;
+		}
+
+		if (SORT_CONDITION_MAP.containsKey(sortCondition)) {
+			return SORT_CONDITION_MAP.get(sortCondition);
+		}
+
+		throw new BusinessException(ErrorCode.REVIEW_BAD_SORT_CONDITION);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursor.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewRepositoryForCursor.java
@@ -4,13 +4,15 @@ import java.util.List;
 
 import com.programmers.lime.domains.review.model.MemberInfoWithReviewId;
 import com.programmers.lime.domains.review.model.ReviewCursorIdInfo;
+import com.programmers.lime.domains.review.model.ReviewSortCondition;
 import com.programmers.lime.domains.review.model.ReviewSummary;
 
 public interface ReviewRepositoryForCursor {
 	List<ReviewCursorIdInfo> findAllByCursor(
 		Long itemId,
 		String cursorId,
-		int pageSize
+		int pageSize,
+		ReviewSortCondition reviewSortCondition
 	);
 
 	List<MemberInfoWithReviewId> getMemberInfos(List<Long> reviewIds);

--- a/lime-domain/src/test/java/com/programmers/lime/domains/review/implementation/ReviewCursorReaderTest.java
+++ b/lime-domain/src/test/java/com/programmers/lime/domains/review/implementation/ReviewCursorReaderTest.java
@@ -73,7 +73,8 @@ class ReviewCursorReaderTest {
 		given(reviewRepository.findAllByCursor(
 				itemId,
 				parameters.cursorId(),
-				pageSize
+				pageSize,
+			null
 			)
 		).willReturn(reviewCursorIdInfos);
 
@@ -87,7 +88,8 @@ class ReviewCursorReaderTest {
 		CursorSummary<ReviewCursorSummary> actualReviewCursorSummary = reviewCursorReader.readByCursor(
 			itemId,
 			memberId,
-			parameters
+			parameters,
+			null
 		);
 
 		// then


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

#### 리뷰 목록 조회 정렬 조건 추가 ❤😊
- NEWEST(최신순), LOWEST_RATE(평점 낮은 순), HIGHEST_RATE(평점 높은 순)등의 정렬 조건을 추가하였습니다. ded2b633195dd19dd1a92ef230826e2132ef98af
- LIKE_COUNT_DESC(좋아요 순)은 좋아요 기능이 추가 되면 추가 됩니다. 
- 정렬조건 추가로 인한 테스트 코드 수정 2c88b0126512db0df216d88c4284a983762edff4

### Issue Number

[LIME-66]

### 기능 설명

#### 정렬 조건 추가 기능 설명 ❤😊
- 정렬 조건을 추가하기 위해 generateCursorId 메서드를 수정 하였습니다.
- 기존에 정렬을 위해 date기준으로 커서 아이디를 만들었습니다. 
- 이를 응용하여 generateCursorId에 각 정렬기준 마다 데이터를 변경하여 커서 아이디를 생성하게 하였습니다.


## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-66]: https://uju-lime.atlassian.net/browse/LIME-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ