### PR TITLE
[LIME-93]리뷰 이미지와 리뷰 좋아요가 있는 경우 삭제 안되는 버그 수정

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
@@ -20,6 +20,8 @@ import com.programmers.lime.domains.review.domain.Review;
 import com.programmers.lime.domains.review.implementation.ReviewAppender;
 import com.programmers.lime.domains.review.implementation.ReviewCursorReader;
 import com.programmers.lime.domains.review.implementation.ReviewImageAppender;
+import com.programmers.lime.domains.review.implementation.ReviewImageRemover;
+import com.programmers.lime.domains.review.implementation.ReviewLikeRemover;
 import com.programmers.lime.domains.review.implementation.ReviewModifier;
 import com.programmers.lime.domains.review.implementation.ReviewReader;
 import com.programmers.lime.domains.review.implementation.ReviewRemover;
@@ -52,6 +54,8 @@ public class ReviewService {
 	private final S3Manager s3Manager;
 	private final ApplicationEventPublisher applicationEventPublisher;
 	private final ReviewImageAppender reviewImageAppender;
+	private final ReviewLikeRemover reviewLikeRemover;
+	private final ReviewImageRemover reviewImageRemover;
 
 	@Transactional
 	public void createReview(
@@ -126,6 +130,7 @@ public class ReviewService {
 		return new ReviewGetByCursorServiceResponse(reviewCount, cursorSummary);
 	}
 
+	@Transactional
 	public void deleteReview(
 		final Long itemId,
 		final Long reviewId
@@ -133,6 +138,8 @@ public class ReviewService {
 		Long memberId = memberUtils.getCurrentMemberId();
 		reviewValidator.validItemReview(itemId, reviewId);
 		reviewValidator.validOwner(reviewId, memberId);
+		reviewLikeRemover.deleteByReviewId(reviewId);
+		reviewImageRemover.deleteByReviewId(reviewId);
 		reviewRemover.remove(reviewId);
 	}
 

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewImageRemover.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewImageRemover.java
@@ -1,0 +1,20 @@
+package com.programmers.lime.domains.review.implementation;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.review.repository.ReviewImageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewImageRemover {
+
+	private final ReviewImageRepository reviewImageRepository;
+
+	public void deleteByReviewId(
+		final Long reviewId
+	) {
+		reviewImageRepository.deleteReviewImageByReviewId(reviewId);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewLikeRemover.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewLikeRemover.java
@@ -1,7 +1,6 @@
 package com.programmers.lime.domains.review.implementation;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.lime.domains.review.domain.Review;
 import com.programmers.lime.domains.review.repository.ReviewLikeRepository;
@@ -15,12 +14,17 @@ public class ReviewLikeRemover {
 	private final ReviewReader reviewReader;
 	private final ReviewLikeRepository reviewLikeRepository;
 
-	@Transactional
 	public void deleteByMemberIdAndReviewId(
 		final Long memberId,
 		final Long reviewId
 	) {
 		Review review = reviewReader.read(reviewId);
 		reviewLikeRepository.deleteReviewLikeByMemberIdAndReview(memberId, review);
+	}
+
+	public void deleteByReviewId(
+		final Long reviewId
+	) {
+		reviewLikeRepository.deleteReviewLikeByReviewId(reviewId);
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewImageRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewImageRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.programmers.lime.domains.review.domain.ReviewImage;
 
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+	void deleteReviewImageByReviewId(Long reviewId);
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewLikeRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/repository/ReviewLikeRepository.java
@@ -16,4 +16,6 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 		final Long memberId,
 		final Long reviewId
 	);
+
+	void deleteReviewLikeByReviewId(Long reviewId);
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?


#### ❤ reviews 테이블과 연관 관계가 있는 review_likes, review_images 테이블에 데이터가 있는 경우 삭제 안되는 버그 수정 54680142d77649d56c42d445dc0b564f76670305
- fk 제약 설정으로 인해 db에서 예외 발생하였습니다.
- review_likes, review_images에 review id가 있는 경우 관련 row를 삭제하고 review를 삭제 하도록 변경하였습니다. 

### Issue Number

[LIME-93]

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-93]: https://uju-lime.atlassian.net/browse/LIME-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ