### PR TITLE
[LIME-95] 찜 폴더 이동 기능 추가

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
@@ -17,6 +17,7 @@ import com.programmers.lime.domains.item.api.dto.request.ItemEnrollRequest;
 import com.programmers.lime.domains.item.api.dto.request.MemberItemCreateRequest;
 import com.programmers.lime.domains.item.api.dto.request.MemberItemFolderCreateRequest;
 import com.programmers.lime.domains.item.api.dto.request.MemberItemFolderUpdateRequest;
+import com.programmers.lime.domains.item.api.dto.request.MemberItemMoveRequest;
 import com.programmers.lime.domains.item.api.dto.response.MemberItemCreateResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemEnrollResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetByCursorResponse;
@@ -165,5 +166,18 @@ public class ItemController {
 		);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "찜 이동", description = "찜을 다른 폴더로 이동 합니다.")
+	@PutMapping("/myitems/move")
+	public ResponseEntity<Void> moveMemberItems(
+		@RequestBody @Valid final MemberItemMoveRequest request
+	) {
+		itemService.moveMemberItems(
+			request.folderId(),
+			request.memberItemIds()
+		);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/dto/request/MemberItemMoveRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/dto/request/MemberItemMoveRequest.java
@@ -1,0 +1,17 @@
+package com.programmers.lime.domains.item.api.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberItemMoveRequest(
+
+	@Schema(description = "이동할 폴더 id", example = "1")
+	Long folderId,
+
+	@Schema(description = "이동할 찜 아이템 목록", example = "[1, 2, 3]")
+	@NotNull(message = "찜 아이템 목록은 필수 값 입니다.")
+	List<Long> memberItemIds
+) {
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
@@ -185,4 +185,16 @@ public class ItemService {
 	public List<ItemRankingServiceResponse> getRanking() {
 		return itemRanking.viewRanking();
 	}
+
+	public void moveMemberItems(
+		final Long folderId,
+		final List<Long> memberItemIds
+	) {
+		Long memberId = memberUtils.getCurrentMemberId();
+
+		memberItemValidator.validateExistMemberIdAndMemberItemId(memberId, memberItemIds);
+		memberItemFolderValidator.validateExsitMemberItemFolder(folderId, memberId);
+
+		memberItemAppender.moveMemberItems(folderId, memberItemIds);
+	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/domain/MemberItem.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/domain/MemberItem.java
@@ -47,4 +47,8 @@ public class MemberItem extends BaseEntity {
 		this.item = Objects.requireNonNull(item);
 		this.folderId = folderId;
 	}
+
+	public void moveFolder(final Long folderId) {
+		this.folderId = folderId;
+	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemAppender.java
@@ -62,4 +62,14 @@ public class MemberItemAppender {
 			.map(itemReader::read)
 			.toList();
 	}
+
+	public void moveMemberItems(
+		final Long folderId,
+		final List<Long> memberItemIds
+	) {
+		List<MemberItem> memberItems = memberItemRepository.findAllById(memberItemIds);
+		memberItems.forEach(memberItem -> memberItem.moveFolder(folderId));
+
+		memberItemRepository.saveAll(memberItems);
+	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
#### 찜 한 아이템에 한하여 폴더 이동을 하도록 기능 추가하였습니다. ❤ efb92811d72b04214fddd67116c2429cb754ee65

### Issue Number

[LIME-95] 
### 기능 설명

#### 찜 아이템 폴더 이동 기능 추가 ❤
- 찜 아이템 아이디가 나의 아이템인지 검증 합니다.
- 이동할 폴더 아이디도 나의 폴더인지 확인 합니다.
- 이 후 찜 아이템의 folder_id를 변경하고 데이터 베이스에 저장 합니다. 
- folder_id가 null 이면 최상위 폴더에 있다는 의미 입니다. 😊

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-95]: https://uju-lime.atlassian.net/browse/LIME-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ