### PR TITLE
[LIME-96] 폴더에 포함되어 있는 아이템 개수 반환 기능 추가

### DIFF
--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderFavoriteInfoReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderFavoriteInfoReader.java
@@ -65,7 +65,12 @@ public class MemberItemFolderFavoriteInfoReader implements IFavoriteReader {
 			.collect(Collectors.toCollection(ArrayList::new));
 
 		return MemberItemFavoriteMetadata.builder()
-			.memberItemFolderMetadata(new MemberItemFolderMetadata(imageUrls))
+			.memberItemFolderMetadata(
+				MemberItemFolderMetadata.builder()
+					.imageUrls(imageUrls)
+					.itemCount(memberItems.size())
+					.build()
+			)
 			.build();
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/MemberItemFolderMetadata.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/MemberItemFolderMetadata.java
@@ -2,7 +2,11 @@ package com.programmers.lime.domains.item.model;
 
 import java.util.List;
 
+import lombok.Builder;
+
+@Builder
 public record MemberItemFolderMetadata (
-	List<String> imageUrls
+	List<String> imageUrls,
+	int itemCount
 ){
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
#### 찜 목록 조회할 경우 폴더에 포함되어 있는 아이템 수 반환 기능 추가
- 폴더 안에 포함되어 있는 아이템 수를 반환 하도록 기능이 추가되었습니다.

### Issue Number

[LIME-96]

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-96]: https://uju-lime.atlassian.net/browse/LIME-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ