### PR TITLE
[LIME-97] favorite item 리팩토링

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/FavoriteItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/FavoriteItemController.java
@@ -1,0 +1,115 @@
+package com.programmers.lime.domains.favoriteItem.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.programmers.lime.domains.favoriteItem.api.dto.request.FavoriteItemDeleteRequest;
+import com.programmers.lime.domains.favoriteItem.api.dto.request.MemberItemCreateRequest;
+import com.programmers.lime.domains.favoriteItem.api.dto.request.MemberItemFolderCreateRequest;
+import com.programmers.lime.domains.favoriteItem.api.dto.request.MemberItemFolderUpdateRequest;
+import com.programmers.lime.domains.favoriteItem.api.dto.request.MemberItemMoveRequest;
+import com.programmers.lime.domains.favoriteItem.api.dto.response.MemberItemCreateResponse;
+import com.programmers.lime.domains.favoriteItem.api.dto.response.MemberItemFavoritesGetResponse;
+import com.programmers.lime.domains.favoriteItem.application.FavoriteItemService;
+import com.programmers.lime.domains.favoriteItem.application.MemberItemFolderService;
+import com.programmers.lime.domains.favoriteItem.application.dto.MemberItemCreateServiceResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "favorites", description = "찜 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/items/myitems")
+public class FavoriteItemController {
+
+	private final FavoriteItemService favoriteItemService;
+
+	private final MemberItemFolderService memberItemFolderService;
+
+	@Operation(summary = "찜 목록에 아이템 넣기", description = "MemberItemAddRequest을 이용하여 사용자의 찜 목록에 아이템 담기 합니다.")
+	@PostMapping()
+	public ResponseEntity<MemberItemCreateResponse> createMemberItems(
+		@Valid @RequestBody final MemberItemCreateRequest request
+	) {
+		MemberItemCreateServiceResponse serviceResponse = favoriteItemService.createMemberItems(
+			request.toMemberItemIdRegistry()
+		);
+		MemberItemCreateResponse response = MemberItemCreateResponse.from(serviceResponse);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "찜 목록 조회", description = "찜 목록을 조회 합니다.")
+	@GetMapping()
+	public ResponseEntity<MemberItemFavoritesGetResponse> getMemberItemObjects(
+		@RequestParam(required = false) final Long folderId
+	) {
+		MemberItemFavoritesGetResponse response = favoriteItemService.getMemberItemFavorites(
+			folderId
+		);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "찜 이동", description = "찜을 다른 폴더로 이동 합니다.")
+	@PutMapping("/move")
+	public ResponseEntity<Void> moveMemberItems(
+		@RequestBody @Valid final MemberItemMoveRequest request
+	) {
+		favoriteItemService.moveMemberItems(
+			request.folderId(),
+			request.memberItemIds()
+		);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "찜 항목 제거", description = "찜 목록으로 부터 아이템이나 폴더를 제거 합니다.")
+	@DeleteMapping()
+	public ResponseEntity<Void> removeFavorite(
+		@ModelAttribute @Valid final FavoriteItemDeleteRequest request
+	) {
+		favoriteItemService.removeMemberItems(request.itemIds());
+		memberItemFolderService.removeMemberItemFolders(request.folderIds());
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "찜 목록폴더 생성", description = "찜 목록 폴더를 생성 합니다.")
+	@PostMapping("/folders")
+	public ResponseEntity<Void> addMemberItemFolder(
+		@RequestBody @Valid final MemberItemFolderCreateRequest request
+	) {
+		memberItemFolderService.createMemberItemFolder(
+			request.folderName()
+		);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "찜 목록 폴더 수정", description = "찜 목록 폴더를 수정 합니다.")
+	@PutMapping("/folders/{folderId}")
+	public ResponseEntity<Void> modifyMemberItemFolder(
+		@PathVariable final Long folderId,
+		@RequestBody @Valid final MemberItemFolderUpdateRequest request
+	) {
+		memberItemFolderService.modifyMemberItemFolder(
+			folderId,
+			request.folderName()
+		);
+
+		return ResponseEntity.ok().build();
+	}
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/FavoriteItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/FavoriteItemController.java
@@ -70,7 +70,7 @@ public class FavoriteItemController {
 	) {
 		favoriteItemService.moveMemberItems(
 			request.folderId(),
-			request.memberItemIds()
+			request.favoriteItemIds()
 		);
 
 		return ResponseEntity.ok().build();
@@ -81,7 +81,7 @@ public class FavoriteItemController {
 	public ResponseEntity<Void> removeFavorite(
 		@ModelAttribute @Valid final FavoriteItemDeleteRequest request
 	) {
-		favoriteItemService.removeMemberItems(request.itemIds());
+		favoriteItemService.removeMemberItems(request.favoriteItemIds());
 		memberItemFolderService.removeMemberItemFolders(request.folderIds());
 
 		return ResponseEntity.ok().build();

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/FavoriteItemDeleteRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/FavoriteItemDeleteRequest.java
@@ -5,8 +5,8 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FavoriteItemDeleteRequest (
-	@Schema(description = "여러 아이템 id", example = "1, 2, 3")
-	List<Long> itemIds,
+	@Schema(description = "여러 찜한 아이템 id", example = "1, 2, 3")
+	List<Long> favoriteItemIds,
 
 	@Schema(description = "여러 폴더 id", example = "1, 2, 3")
 	List<Long> folderIds

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/FavoriteItemDeleteRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/FavoriteItemDeleteRequest.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.api.dto.request;
+package com.programmers.lime.domains.favoriteItem.api.dto.request;
 
 import java.util.List;
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemCreateRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemCreateRequest.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.api.dto.request;
+package com.programmers.lime.domains.favoriteItem.api.dto.request;
 
 import java.util.List;
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemFolderCreateRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemFolderCreateRequest.java
@@ -1,14 +1,13 @@
-package com.programmers.lime.domains.item.api.dto.request;
+package com.programmers.lime.domains.favoriteItem.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record MemberItemFolderUpdateRequest(
-
+public record MemberItemFolderCreateRequest(
 	@Schema(description = "폴더 이름", example = "농구 취미 폴더")
 	@NotNull(message = "폴더 이름을 입력하지 않았습니다.")
 	@Size(min = 1, max = 20, message = "폴더 이름은 1자 이상 20자 이하로 입력해주세요.")
 	String folderName
-) {
+){
 }

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemFolderUpdateRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemFolderUpdateRequest.java
@@ -1,13 +1,14 @@
-package com.programmers.lime.domains.item.api.dto.request;
+package com.programmers.lime.domains.favoriteItem.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record MemberItemFolderCreateRequest(
+public record MemberItemFolderUpdateRequest(
+
 	@Schema(description = "폴더 이름", example = "농구 취미 폴더")
 	@NotNull(message = "폴더 이름을 입력하지 않았습니다.")
 	@Size(min = 1, max = 20, message = "폴더 이름은 1자 이상 20자 이하로 입력해주세요.")
 	String folderName
-){
+) {
 }

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemMoveRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemMoveRequest.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.api.dto.request;
+package com.programmers.lime.domains.favoriteItem.api.dto.request;
 
 import java.util.List;
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemMoveRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/request/MemberItemMoveRequest.java
@@ -12,6 +12,6 @@ public record MemberItemMoveRequest(
 
 	@Schema(description = "이동할 찜 아이템 목록", example = "[1, 2, 3]")
 	@NotNull(message = "찜 아이템 목록은 필수 값 입니다.")
-	List<Long> memberItemIds
+	List<Long> favoriteItemIds
 ) {
 }

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/FolderGetByCursorResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/FolderGetByCursorResponse.java
@@ -1,8 +1,8 @@
-package com.programmers.lime.domains.item.api.dto.response;
+package com.programmers.lime.domains.favoriteItem.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.lime.domains.item.application.dto.FolderGetByCursorServiceResponse;
+import com.programmers.lime.domains.favoriteItem.application.dto.FolderGetByCursorServiceResponse;
 import com.programmers.lime.domains.item.model.MemberItemFolderCursorSummary;
 
 public record FolderGetByCursorResponse(

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemCreateResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemCreateResponse.java
@@ -1,8 +1,8 @@
-package com.programmers.lime.domains.item.api.dto.response;
+package com.programmers.lime.domains.favoriteItem.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.lime.domains.item.application.dto.MemberItemCreateServiceResponse;
+import com.programmers.lime.domains.favoriteItem.application.dto.MemberItemCreateServiceResponse;
 
 public record MemberItemCreateResponse(List<Long> itemIds) {
 	public static MemberItemCreateResponse from(final MemberItemCreateServiceResponse response) {

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemFavoritesGetResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemFavoritesGetResponse.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.api.dto.response;
+package com.programmers.lime.domains.favoriteItem.api.dto.response;
 
 import java.util.List;
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemFolderGetByCursorResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemFolderGetByCursorResponse.java
@@ -1,9 +1,9 @@
-package com.programmers.lime.domains.item.api.dto.response;
+package com.programmers.lime.domains.favoriteItem.api.dto.response;
 
 import java.util.List;
 
 import com.programmers.lime.common.cursor.CursorSummary;
-import com.programmers.lime.domains.item.application.dto.MemberItemFolderGetServiceResponse;
+import com.programmers.lime.domains.favoriteItem.application.dto.MemberItemFolderGetServiceResponse;
 import com.programmers.lime.domains.item.model.MemberItemFolderCursorSummary;
 
 public record MemberItemFolderGetByCursorResponse (

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemGetByCursorResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/api/dto/response/MemberItemGetByCursorResponse.java
@@ -1,8 +1,8 @@
-package com.programmers.lime.domains.item.api.dto.response;
+package com.programmers.lime.domains.favoriteItem.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.lime.domains.item.application.dto.MemberItemGetServiceResponse;
+import com.programmers.lime.domains.favoriteItem.application.dto.MemberItemGetServiceResponse;
 import com.programmers.lime.domains.item.model.MemberItemSummary;
 
 public record MemberItemGetByCursorResponse(

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/FavoriteItemService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/FavoriteItemService.java
@@ -1,0 +1,108 @@
+package com.programmers.lime.domains.favoriteItem.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.programmers.lime.domains.favoriteItem.api.dto.response.MemberItemFavoritesGetResponse;
+import com.programmers.lime.domains.favoriteItem.application.dto.MemberItemCreateServiceResponse;
+import com.programmers.lime.domains.item.domain.Item;
+import com.programmers.lime.domains.item.implementation.ItemReader;
+import com.programmers.lime.domains.item.implementation.MemberItemAppender;
+import com.programmers.lime.domains.item.implementation.MemberItemFavoriteReader;
+import com.programmers.lime.domains.item.implementation.MemberItemFolderValidator;
+import com.programmers.lime.domains.item.implementation.MemberItemRemover;
+import com.programmers.lime.domains.item.implementation.MemberItemValidator;
+import com.programmers.lime.domains.item.model.MemberItemFavoriteInfo;
+import com.programmers.lime.domains.item.model.MemberItemIdRegistry;
+import com.programmers.lime.global.util.MemberUtils;
+import com.programmers.lime.redis.implement.ItemRanking;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteItemService {
+
+	private final MemberItemAppender memberItemAppender;
+
+	private final MemberItemFavoriteReader memberItemFavoriteReader;
+
+	private final MemberItemRemover memberItemRemover;
+
+	private final ItemReader itemReader;
+
+	private final ItemRanking itemRanking;
+
+	private final MemberUtils memberUtils;
+
+	private final MemberItemValidator memberItemValidator;
+
+	private final MemberItemFolderValidator memberItemFolderValidator;
+
+	public MemberItemCreateServiceResponse createMemberItems(
+		final MemberItemIdRegistry memberItemIdRegistry
+	) {
+		updateItemRanking(memberItemIdRegistry);
+
+		Long memberId = memberUtils.getCurrentMemberId();
+		List<Long> memberItemIds = memberItemAppender.appendMemberItems(
+			memberItemIdRegistry.itemIds(),
+			memberItemIdRegistry.folderId(),
+			memberId
+		);
+
+		return new MemberItemCreateServiceResponse(memberItemIds);
+	}
+
+	private void updateItemRanking(final MemberItemIdRegistry memberItemIdRegistry) {
+		List<String> items = memberItemIdRegistry.itemIds().stream()
+			.map(itemReader::read)
+			.map(Item::getName)
+			.toList();
+
+		for (String itemName : items) {
+			itemRanking.increasePoint(itemName, 1);
+		}
+	}
+
+	public MemberItemFavoritesGetResponse getMemberItemFavorites(
+		final Long folderId
+	) {
+		Long memberId = memberUtils.getCurrentMemberId();
+
+		memberItemFolderValidator.validateExsitMemberItemFolder(folderId, memberId);
+		List<MemberItemFavoriteInfo> memberItemFavoriteInfos = memberItemFavoriteReader.readObjects(folderId, memberId);
+
+		return new MemberItemFavoritesGetResponse(memberItemFavoriteInfos.size(), memberItemFavoriteInfos);
+	}
+
+	public void moveMemberItems(
+		final Long folderId,
+		final List<Long> memberItemIds
+	) {
+		Long memberId = memberUtils.getCurrentMemberId();
+
+		memberItemValidator.validateExistMemberIdAndMemberItemId(memberId, memberItemIds);
+		memberItemFolderValidator.validateExsitMemberItemFolder(folderId, memberId);
+
+		memberItemAppender.moveMemberItems(folderId, memberItemIds);
+	}
+
+	public void removeMemberItems(
+		final List<Long> memberItemIds
+	) {
+
+		if(memberItemIds == null || memberItemIds.isEmpty()) {
+			return;
+		}
+
+		Long memberId = memberUtils.getCurrentMemberId();
+
+		memberItemValidator.validateExistMemberIdAndMemberItemId(memberId, memberItemIds);
+
+		for (Long memberItemId : memberItemIds) {
+			memberItemRemover.remove(memberItemId);
+		}
+	}
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/MemberItemFolderService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/MemberItemFolderService.java
@@ -1,8 +1,9 @@
-package com.programmers.lime.domains.item.application;
+package com.programmers.lime.domains.favoriteItem.application;
 
 import java.util.List;
 
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import com.programmers.lime.domains.item.implementation.MemberItemFolderAppender;
 import com.programmers.lime.domains.item.implementation.MemberItemFolderModifier;
@@ -12,7 +13,7 @@ import com.programmers.lime.global.util.MemberUtils;
 
 import lombok.RequiredArgsConstructor;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class MemberItemFolderService {
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/FolderGetByCursorServiceResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/FolderGetByCursorServiceResponse.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.application.dto;
+package com.programmers.lime.domains.favoriteItem.application.dto;
 
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.domains.item.model.MemberItemFolderCursorSummary;

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/MemberItemCreateServiceResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/MemberItemCreateServiceResponse.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.application.dto;
+package com.programmers.lime.domains.favoriteItem.application.dto;
 
 import java.util.List;
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/MemberItemFolderGetServiceResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/MemberItemFolderGetServiceResponse.java
@@ -1,8 +1,7 @@
-package com.programmers.lime.domains.item.application.dto;
+package com.programmers.lime.domains.favoriteItem.application.dto;
 
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.domains.item.model.MemberItemFolderCursorSummary;
-import com.programmers.lime.domains.item.model.MemberItemFolderSummary;
 
 public record MemberItemFolderGetServiceResponse(
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/MemberItemGetServiceResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/favoriteItem/application/dto/MemberItemGetServiceResponse.java
@@ -1,4 +1,4 @@
-package com.programmers.lime.domains.item.application.dto;
+package com.programmers.lime.domains.favoriteItem.application.dto;
 
 import com.programmers.lime.common.cursor.CursorSummary;
 import com.programmers.lime.domains.item.model.MemberItemSummary;

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
@@ -1,34 +1,23 @@
 package com.programmers.lime.domains.item.api;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.programmers.lime.domains.item.api.dto.request.FavoriteItemDeleteRequest;
 import com.programmers.lime.domains.item.api.dto.request.ItemEnrollRequest;
-import com.programmers.lime.domains.item.api.dto.request.MemberItemCreateRequest;
-import com.programmers.lime.domains.item.api.dto.request.MemberItemFolderCreateRequest;
-import com.programmers.lime.domains.item.api.dto.request.MemberItemFolderUpdateRequest;
-import com.programmers.lime.domains.item.api.dto.request.MemberItemMoveRequest;
-import com.programmers.lime.domains.item.api.dto.response.MemberItemCreateResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemEnrollResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetByCursorResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetNamesResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetRankingResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetResponse;
-import com.programmers.lime.domains.item.api.dto.response.MemberItemFavoritesGetResponse;
 import com.programmers.lime.domains.item.application.ItemEnrollService;
 import com.programmers.lime.domains.item.application.ItemService;
-import com.programmers.lime.domains.item.application.MemberItemFolderService;
-import com.programmers.lime.domains.item.application.dto.MemberItemCreateServiceResponse;
 import com.programmers.lime.domains.item.application.dto.ItemGetByCursorServiceResponse;
 import com.programmers.lime.domains.item.application.dto.ItemGetNamesServiceResponse;
 import com.programmers.lime.domains.item.application.dto.ItemGetServiceResponse;
@@ -49,27 +38,12 @@ public class ItemController {
 
 	private final ItemService itemService;
 
-	private final MemberItemFolderService memberItemFolderService;
-
 	@Operation(summary = "아이템 등록", description = "ItemEnrollRequest 을 이용하여 아이템을 등록합니다.")
 	@PostMapping("/enroll")
 
 	public ResponseEntity<ItemEnrollResponse> enrollItem(@Valid @RequestBody final ItemEnrollRequest request) {
 		Long enrolledItemId = itemEnrollService.enrollItem(request.toEnrollItemServiceRequest());
 		ItemEnrollResponse response = new ItemEnrollResponse(enrolledItemId);
-
-		return ResponseEntity.ok(response);
-	}
-
-	@Operation(summary = "찜 목록에 아이템 넣기", description = "MemberItemAddRequest을 이용하여 사용자의 찜 목록에 아이템 담기 합니다.")
-	@PostMapping("/myitems")
-	public ResponseEntity<MemberItemCreateResponse> createMemberItems(
-		@Valid @RequestBody final MemberItemCreateRequest request
-	) {
-		MemberItemCreateServiceResponse serviceResponse = itemService.createMemberItems(
-			request.toMemberItemIdRegistry()
-		);
-		MemberItemCreateResponse response = MemberItemCreateResponse.from(serviceResponse);
 
 		return ResponseEntity.ok(response);
 	}
@@ -117,67 +91,5 @@ public class ItemController {
 		ItemGetRankingResponse response = ItemGetRankingResponse.from(itemService.getRanking());
 
 		return ResponseEntity.ok(response);
-	}
-
-	@Operation(summary = "찜 목록폴더 생성", description = "찜 목록 폴더를 생성 합니다.")
-	@PostMapping("/myitems/folders")
-	public ResponseEntity<Void> addMemberItemFolder(
-		@RequestBody @Valid final MemberItemFolderCreateRequest request
-	) {
-		memberItemFolderService.createMemberItemFolder(
-			request.folderName()
-		);
-
-		return ResponseEntity.ok().build();
-	}
-
-  	@Operation(summary = "찜 목록 폴더 수정", description = "찜 목록 폴더를 수정 합니다.")
-	@PutMapping("/myitems/folders/{folderId}")
-	public ResponseEntity<Void> modifyMemberItemFolder(
-		@PathVariable final Long folderId,
-		@RequestBody @Valid final MemberItemFolderUpdateRequest request
-	) {
-		memberItemFolderService.modifyMemberItemFolder(
-			folderId,
-			request.folderName()
-		);
-
-		return ResponseEntity.ok().build();
-	}
-
-	@Operation(summary = "찜 항목 제거", description = "찜 목록으로 부터 아이템이나 폴더를 제거 합니다.")
-	@DeleteMapping("/myitems")
-	public ResponseEntity<Void> removeFavorite(
-		@ModelAttribute @Valid final FavoriteItemDeleteRequest request
-	) {
-		itemService.removeMemberItems(request.itemIds());
-		memberItemFolderService.removeMemberItemFolders(request.folderIds());
-
-		return ResponseEntity.ok().build();
-	}
-
-	@Operation(summary = "찜 목록 조회", description = "찜 목록을 조회 합니다.")
-	@GetMapping("/myitems")
-	public ResponseEntity<MemberItemFavoritesGetResponse> getMemberItemObjects(
-		@RequestParam(required = false) final Long folderId
-	) {
-		MemberItemFavoritesGetResponse response = itemService.getMemberItemFavorites(
-			folderId
-		);
-
-		return ResponseEntity.ok(response);
-	}
-
-	@Operation(summary = "찜 이동", description = "찜을 다른 폴더로 이동 합니다.")
-	@PutMapping("/myitems/move")
-	public ResponseEntity<Void> moveMemberItems(
-		@RequestBody @Valid final MemberItemMoveRequest request
-	) {
-		itemService.moveMemberItems(
-			request.folderId(),
-			request.memberItemIds()
-		);
-
-		return ResponseEntity.ok().build();
 	}
 }

--- a/lime-api/src/test/java/com/programmers/lime/domains/item/application/ItemServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/item/application/ItemServiceTest.java
@@ -9,7 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.programmers.lime.IntegrationTest;
-import com.programmers.lime.domains.item.application.dto.MemberItemCreateServiceResponse;
+import com.programmers.lime.domains.favoriteItem.application.FavoriteItemService;
+import com.programmers.lime.domains.favoriteItem.application.dto.MemberItemCreateServiceResponse;
 import com.programmers.lime.domains.item.domain.setup.ItemSetup;
 import com.programmers.lime.domains.item.implementation.MemberItemValidator;
 import com.programmers.lime.domains.item.model.MemberItemIdRegistry;
@@ -22,7 +23,7 @@ class ItemServiceTest extends IntegrationTest {
 	private ItemSetup itemSetup;
 
 	@Autowired
-	private ItemService itemService;
+	private FavoriteItemService favoriteItemService;
 
 	@MockBean
 	private MemberUtils memberUtils;
@@ -46,7 +47,7 @@ class ItemServiceTest extends IntegrationTest {
 			.forEach(itemId -> itemSetup.saveOne(itemId));
 
 		// when
-		MemberItemCreateServiceResponse actualResponse = itemService.createMemberItems(memberItemIdRegistryBuilder);
+		MemberItemCreateServiceResponse actualResponse = favoriteItemService.createMemberItems(memberItemIdRegistryBuilder);
 
 		// then
 		assertThat(actualResponse)

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFavoriteInfoReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFavoriteInfoReader.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import com.programmers.lime.common.model.FavoriteType;
 import com.programmers.lime.domains.item.domain.Item;
 import com.programmers.lime.domains.item.domain.MemberItem;
-import com.programmers.lime.domains.item.model.MemberItemMetadata;
+import com.programmers.lime.domains.item.model.FavoriteItemMetadata;
 import com.programmers.lime.domains.item.model.MemberItemFavoriteInfo;
 import com.programmers.lime.domains.item.model.MemberItemFavoriteMetadata;
 import com.programmers.lime.domains.review.implementation.ReviewReader;
@@ -47,8 +47,8 @@ public class MemberItemFavoriteInfoReader implements IFavoriteReader {
 		int reviewCount = reviewReader.countReviewByItemId(item.getId());
 		int price = item.getPrice();
 
-		return MemberItemFavoriteMetadata.builder().memberItemMetadata(
-			MemberItemMetadata.builder()
+		return MemberItemFavoriteMetadata.builder().favoriteItemMetadata(
+			FavoriteItemMetadata.builder()
 				.itemId(item.getId())
 				.hobby(item.getHobby())
 				.itemUrl(item.getUrl())

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderFavoriteInfoReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderFavoriteInfoReader.java
@@ -11,7 +11,7 @@ import com.programmers.lime.common.model.FavoriteType;
 import com.programmers.lime.domains.item.domain.Item;
 import com.programmers.lime.domains.item.domain.MemberItem;
 import com.programmers.lime.domains.item.domain.MemberItemFolder;
-import com.programmers.lime.domains.item.model.MemberItemFolderMetadata;
+import com.programmers.lime.domains.item.model.FolderMetadata;
 import com.programmers.lime.domains.item.model.MemberItemFavoriteInfo;
 import com.programmers.lime.domains.item.model.MemberItemFavoriteMetadata;
 
@@ -65,8 +65,8 @@ public class MemberItemFolderFavoriteInfoReader implements IFavoriteReader {
 			.collect(Collectors.toCollection(ArrayList::new));
 
 		return MemberItemFavoriteMetadata.builder()
-			.memberItemFolderMetadata(
-				MemberItemFolderMetadata.builder()
+			.folderMetadata(
+				FolderMetadata.builder()
 					.imageUrls(imageUrls)
 					.itemCount(memberItems.size())
 					.build()

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/FavoriteItemMetadata.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/FavoriteItemMetadata.java
@@ -5,7 +5,7 @@ import com.programmers.lime.common.model.Hobby;
 import lombok.Builder;
 
 @Builder
-public record MemberItemMetadata (
+public record FavoriteItemMetadata(
 	Long itemId,
 	Hobby hobby,
 	String itemUrl,

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/FolderMetadata.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/FolderMetadata.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record MemberItemFolderMetadata (
+public record FolderMetadata(
 	List<String> imageUrls,
 	int itemCount
 ){

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/model/MemberItemFavoriteMetadata.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/model/MemberItemFavoriteMetadata.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberItemFavoriteMetadata(
-	MemberItemMetadata memberItemMetadata,
-	MemberItemFolderMetadata memberItemFolderMetadata
+	FavoriteItemMetadata favoriteItemMetadata,
+	FolderMetadata folderMetadata
 ) {
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
#### 아이템 도메인과 기능 분리 3e4200787eb4b4afb53c55728bcb3a16e0bbe2bf
- 기존 기능을 변경하지 않고 아이템 도메인과 분리하였습니다.

#### API 변수명 favoriteItem, folder로 변수명 변경 9aec33b58876e3b1d801c980b6e2cfa9d428c290
- 기존 favorite item의 변수명이 member item, item 등으로 혼용하여 사용되고 있었습니다.
- folder 또한 memberItemFolder, favoriteItemFolder 등으로 사용되고 있어서 folder로 통일하였습니다.
- 스웨거 문서에서 보여지는 변수명만 favorite item으로 변경하였습니다. 


### Issue Number

[LIME-97]

### 기능 설명

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
