### PR TITLE
[LIME-91] 투표 목록 조회 요구사항 변경 - 투표 상태 조건, 정렬 조건 수정

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
@@ -93,7 +93,7 @@ public class VoteController {
 	@GetMapping
 	public ResponseEntity<VoteGetByCursorResponse> getVotesByCursor(
 		@RequestParam final String hobby,
-		@RequestParam(name = "status") final String statusCondition,
+		@RequestParam(required = false, name = "status") final String statusCondition,
 		@RequestParam(required = false, name = "sort") final String sortCondition,
 		@ModelAttribute @Valid final CursorRequest request
 	) {

--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/application/VoteService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/application/VoteService.java
@@ -130,12 +130,8 @@ public class VoteService {
 	) {
 		final Long memberId = memberUtils.getCurrentMemberId();
 
-		if (memberId == null && statusCondition.isRequiredLogin()) {
+		if (memberId == null && statusCondition != null && statusCondition.isRequiredLogin()) {
 			throw new BusinessException(ErrorCode.UNAUTHORIZED);
-		}
-
-		if (sortCondition.isImpossibleSort(statusCondition)) {
-			throw new BusinessException(ErrorCode.VOTE_CANNOT_SORT);
 		}
 
 		return voteReader.readByCursor(
@@ -160,7 +156,7 @@ public class VoteService {
 
 		final CursorSummary<VoteSummary> cursorSummary = voteReader.readByCursor(
 			null,
-			VoteStatusCondition.COMPLETED,
+			null,
 			VoteSortCondition.RECENT,
 			keyword,
 			parameters,

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/model/VoteSortCondition.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/model/VoteSortCondition.java
@@ -16,7 +16,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum VoteSortCondition {
 	POPULARITY("popularity"),
-	RECENT("recent");
+	RECENT("recent"),
+	CLOSED("closed"),
+	;
 
 	private static final Map<String, VoteSortCondition> SORT_CONDITION_MAP;
 
@@ -37,9 +39,5 @@ public enum VoteSortCondition {
 		}
 
 		throw new BusinessException(ErrorCode.VOTE_BAD_SORT_CONDITION);
-	}
-
-	public boolean isImpossibleSort(final VoteStatusCondition statusCondition) {
-		return this == VoteSortCondition.POPULARITY && statusCondition != VoteStatusCondition.COMPLETED;
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/model/VoteStatusCondition.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/model/VoteStatusCondition.java
@@ -15,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum VoteStatusCondition {
-	INPROGRESS("inprogress"),
-	COMPLETED("completed"),
 	POSTED("posted"),
 	PARTICIPATED("participated");
 
@@ -30,6 +28,10 @@ public enum VoteStatusCondition {
 	private final String name;
 
 	public static VoteStatusCondition from(final String name) {
+		if (name == null) {
+			return null;
+		}
+
 		if (STATUS_CONDITION_MAP.containsKey(name)) {
 			return STATUS_CONDITION_MAP.get(name);
 		}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -76,7 +76,7 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 			.fetchOne();
 	}
 
-	private  BooleanExpression eqHobby(final Hobby hobby) {
+	private BooleanExpression eqHobby(final Hobby hobby) {
 		if (hobby == null) {
 			return null;
 		}
@@ -88,26 +88,21 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 		final VoteStatusCondition statusCondition,
 		final Long memberId
 	) {
+		if (statusCondition == null) {
+			return null;
+		}
+
 		switch (statusCondition) {
-			case INPROGRESS -> {
-				return isInProgress();
-			}
-			case COMPLETED -> {
-				return isCompleted();
-			}
 			case POSTED -> {
 				return isPosted(memberId);
 			}
 			case PARTICIPATED -> {
 				return isParticipatedIn(memberId);
 			}
+			default -> {
+				return null;
+			}
 		}
-
-		return null;
-	}
-
-	private BooleanExpression isInProgress() {
-		return vote.endTime.after(LocalDateTime.now());
 	}
 
 	private BooleanExpression isCompleted() {
@@ -124,11 +119,20 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 	}
 
 	private OrderSpecifier<?> getOrderSpecifierBy(final VoteSortCondition sortCondition) {
-		if (sortCondition == VoteSortCondition.POPULARITY) {
-			return new OrderSpecifier<>(Order.DESC, vote.voters.size());
+		switch (sortCondition) {
+			case POPULARITY -> {
+				return new OrderSpecifier<>(Order.DESC, vote.voters.size());
+			}
+			case RECENT -> {
+				return new OrderSpecifier<>(Order.DESC, vote.createdAt);
+			}
+			case CLOSED -> {
+				return new OrderSpecifier<>(Order.ASC, vote.endTime);
+			}
+			default -> {
+				return null;
+			}
 		}
-
-		return new OrderSpecifier<>(Order.DESC, vote.createdAt);
 	}
 
 	private BooleanExpression containsKeyword(final String keyword) {

--- a/lime-domain/src/test/java/com/programmers/lime/domains/vote/implementation/VoteReaderTest.java
+++ b/lime-domain/src/test/java/com/programmers/lime/domains/vote/implementation/VoteReaderTest.java
@@ -137,7 +137,7 @@ class VoteReaderTest {
 		// given
 		final int DEFAULT_PAGING_SIZE = 20;
 		final Hobby hobby = Hobby.BASKETBALL;
-		final VoteStatusCondition statusCondition = VoteStatusCondition.COMPLETED;
+		final VoteStatusCondition statusCondition = null;
 		final VoteSortCondition sortCondition = VoteSortCondition.RECENT;
 		final CursorPageParameters parameters = CursorPageParametersBuilder.build();
 		final Long memberId = 1L;

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/model/VoteCreateImplRequestBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/model/VoteCreateImplRequestBuilder.java
@@ -13,6 +13,7 @@ public class VoteCreateImplRequestBuilder {
 			.content("농구공 사려는데 뭐가 더 좋음?")
 			.item1Id(1L)
 			.item2Id(2L)
+			.maximumParticipants(100)
 			.build();
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME-91

### 기능 설명

#### 투표 상태 조건 변경 ✨
- 기존의 상태 조건은 `종료된 투표`, `진행 중인 투표`, `내가 올린 투표`, `내가 참여한 투표` 4가지가 있었습니다.
- 변경된 요구사항은 종료된 투표와 진행 중인 투표를 함께 보여줘야 하기 때문에 투표 상태 조건에서 `종료된 투표`, `진행 중인 투표`를 삭제하였습니다.
- 따라서 상태 조건이 필수 값에서 옵션 값으로 변경되었고, 클라이언트 측에서 상태 조건을 보내지 않을 경우 조건절에 걸리지 않도록 null로 처리하였습니다.

#### 투표 정렬 조건 변경 ✨
- 기존의 정렬 조건은 `인기순`, `최신순` 2가지가 있었고, 여기에 `마감순`을 추가하였습니다.
- 마감순은 투표 마감 시간으로 정렬하였습니다.


<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
- 위에서 설명한 바와 같습니다.