### PR TITLE
[LIME-103] Bucket bulk-insert 리팩토링

### DIFF
--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/domain/Bucket.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/domain/Bucket.java
@@ -1,20 +1,14 @@
 package com.programmers.lime.domains.bucket.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.programmers.lime.common.model.Hobby;
 import com.programmers.lime.domains.BaseEntity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/domain/BucketItem.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/domain/BucketItem.java
@@ -1,16 +1,10 @@
 package com.programmers.lime.domains.bucket.domain;
 
-import com.programmers.lime.domains.BaseEntity;
-import com.programmers.lime.domains.item.domain.Item;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "bucket_items")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BucketItem extends BaseEntity {
+public class BucketItem{
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,6 +31,16 @@ public class BucketItem extends BaseEntity {
 		final Long itemId,
 		final Long bucketId
 	){
+		this.itemId = itemId;
+		this.bucketId = bucketId;
+	}
+
+	public BucketItem(
+		final Long id,
+		final Long itemId,
+		final Long bucketId
+	){
+		this.id = id;
 		this.itemId = itemId;
 		this.bucketId = bucketId;
 	}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/implementation/BucketAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/implementation/BucketAppender.java
@@ -1,7 +1,6 @@
 package com.programmers.lime.domains.bucket.implementation;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +11,6 @@ import com.programmers.lime.domains.bucket.domain.BucketInfo;
 import com.programmers.lime.domains.bucket.domain.BucketItem;
 import com.programmers.lime.domains.bucket.repository.BucketItemRepository;
 import com.programmers.lime.domains.bucket.repository.BucketRepository;
-import com.programmers.lime.domains.item.domain.Item;
 import com.programmers.lime.domains.item.implementation.ItemReader;
 import com.programmers.lime.error.BusinessException;
 import com.programmers.lime.error.ErrorCode;

--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/implementation/BucketRemover.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/implementation/BucketRemover.java
@@ -26,17 +26,14 @@ public class BucketRemover {
 		final Long bucketId,
 		final Long memberId
 	) {
-		List<BucketItem> bucketItems = bucketReader.readBucketItems(bucketId);
 		Bucket bucket = bucketReader.read(bucketId, memberId);
 
-		bucketItemRepository.deleteAll(bucketItems);
+		bucketItemRepository.deleteAll(bucketId);
 		bucketRepository.delete(bucket);
 	}
 
 	/** 버킷 아이템 삭제 */
 	public void removeBucketItems(final Long bucketId) {
-		List<BucketItem> bucketItems = bucketReader.readBucketItems(bucketId);
-
-		bucketItemRepository.deleteAll(bucketItems);
+		bucketItemRepository.deleteAll(bucketId);
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/repository/BucketItemRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/repository/BucketItemRepository.java
@@ -42,7 +42,7 @@ public class BucketItemRepository {
 	}
 
 	public void deleteAll(Long bucketId) {
-		String sql = "DELETE FROM BucketItems WHERE bucket_id = ?";
+		String sql = "DELETE FROM bucket_items WHERE bucket_id = ?";
 
 		jdbcTemplate.batchUpdate(sql,
 			new BatchPreparedStatementSetter() {
@@ -62,7 +62,7 @@ public class BucketItemRepository {
 	}
 
 	public List<BucketItem> findAllByBucketId(final Long bucketId) {
-		String sql = "SELECT * FROM BucketItems WHERE bucket_id = ?";
+		String sql = "SELECT * FROM bucket_items WHERE bucket_id = ?";
 		return jdbcTemplate.query(sql, bucketItemRowMapper(), bucketId);
 	}
 

--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/repository/BucketItemRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/repository/BucketItemRepository.java
@@ -1,11 +1,78 @@
 package com.programmers.lime.domains.bucket.repository;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 
 import com.programmers.lime.domains.bucket.domain.BucketItem;
 
-public interface BucketItemRepository extends JpaRepository<BucketItem,Long> {
-	List<BucketItem> findAllByBucketId(final Long bucketId);
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BucketItemRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public void saveAll(List<BucketItem> bucketItems) {
+		jdbcTemplate.batchUpdate("INSERT INTO bucket_items(item_id,bucket_id,created_at,modified_at) values (?,?,?,?)",
+			new BatchPreparedStatementSetter() {
+				@Override
+				public void setValues(final PreparedStatement ps, final int i) throws SQLException {
+					BucketItem bucketItem = bucketItems.get(i);
+
+					ps.setLong(1, bucketItem.getItemId());
+					ps.setLong(2, bucketItem.getBucketId());
+					ps.setTimestamp(3, Timestamp.valueOf(LocalDateTime.now()));
+					ps.setTimestamp(4, Timestamp.valueOf(LocalDateTime.now()));
+				}
+
+				@Override
+				public int getBatchSize() {
+					return bucketItems.size();
+				}
+			});
+	}
+
+	public void deleteAll(Long bucketId) {
+		String sql = "DELETE FROM BucketItems WHERE bucket_id = ?";
+
+		jdbcTemplate.batchUpdate(sql,
+			new BatchPreparedStatementSetter() {
+				@Override
+				public void setValues(final PreparedStatement ps, final int i) throws SQLException {
+					ps.setLong(1, bucketId);
+				}
+
+				@Override
+				public int getBatchSize() {
+					if (bucketId == null) {
+						return 0;
+					}
+					return 1;
+				}
+			});
+	}
+
+	public List<BucketItem> findAllByBucketId(final Long bucketId) {
+		String sql = "SELECT * FROM BucketItems WHERE bucket_id = ?";
+		return jdbcTemplate.query(sql, bucketItemRowMapper(), bucketId);
+	}
+
+	private static RowMapper<BucketItem> bucketItemRowMapper() {
+		return (rs, rowNum) ->
+			new BucketItem(
+				rs.getLong("id"),
+				rs.getLong("item_id"),
+				rs.getLong("bucket_id")
+			);
+	}
+
 }

--- a/lime-domain/src/test/java/com/programmers/lime/domains/bucket/implementation/BucketAppenderTest.java
+++ b/lime-domain/src/test/java/com/programmers/lime/domains/bucket/implementation/BucketAppenderTest.java
@@ -17,7 +17,6 @@ import com.programmers.lime.domains.bucket.domain.BucketBuilder;
 import com.programmers.lime.domains.bucket.domain.BucketInfo;
 import com.programmers.lime.domains.bucket.repository.BucketItemRepository;
 import com.programmers.lime.domains.bucket.repository.BucketRepository;
-import com.programmers.lime.domains.item.domain.ItemBuilder;
 import com.programmers.lime.domains.item.implementation.ItemReader;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME - 103

### 기능 설명

JPA의 saveAll 메소드를 사용하면 문제가 있다.

List 자료형으로 데이터를 업로드하게되면 저장되는 엔티티마다 save메소드가 일일히 발생한다. 

<img width="551" alt="스크린샷 2024-02-23 오후 3 02 01" src="https://github.com/uju-in/lime-backend/assets/77893164/d8d601e3-d073-4e38-b845-33b687ab5f33">

그러기 때문에 쿼리도 insert 쿼리가 여러번 만들어져 나가게 된다.

이런 문제를 해결해기 위해 JdbcTemplate를 사용했다.
네이티브 쿼리를 사용하고 batch 단위로 데이터를 insert할 수 있기 때문에 쿼리가 한번만 나가게 된다.

JPA 대산 jdbc를 사용하는 이유
1. 복잡한 쿼리를 대신한다.
2. 쿼리의 성능을 개선한다.
3. 반환값을 원하는대로 커스텀 한다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
