### PR TITLE
[LIME-111] 리뷰 관련 버그 수정 

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/review/application/ReviewService.java
@@ -153,6 +153,11 @@ public class ReviewService {
 	}
 
 	public void removeByReviewImageUrls(final List<String> reviewImageUrls) {
+
+		if(reviewImageUrls == null) {
+			return;
+		}
+
 		try {
 			for (String reviewImageUrl : reviewImageUrls) {
 				s3Manager.deleteObjectByUrl(reviewImageUrl);

--- a/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewLikeRemover.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/review/implementation/ReviewLikeRemover.java
@@ -1,6 +1,7 @@
 package com.programmers.lime.domains.review.implementation;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.lime.domains.review.domain.Review;
 import com.programmers.lime.domains.review.repository.ReviewLikeRepository;
@@ -14,6 +15,7 @@ public class ReviewLikeRemover {
 	private final ReviewReader reviewReader;
 	private final ReviewLikeRepository reviewLikeRepository;
 
+	@Transactional
 	public void deleteByMemberIdAndReviewId(
 		final Long memberId,
 		final Long reviewId


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

#### 리뷰 취소 버그 수정 4327bf1a4c169d287edf232ca55fb89b779deecf
- 리뷰 취소를 할 경우 review_images 테이블에서 관련 row를 삭제합니다.
- 이 때 다음과 같은 예외가 발생하였습니다. `No EntityManager with actual transaction available for current thread - cannot reliably process 'remove' call`
- 메시지를 해석하면 스레드에 transaction이 없어 remove 호출을 신뢰할 수 없다는 의미입닌다.
- @Transcational 을 리뷰 좋아요 삭제 메서드에 붙여주어 원인을 해결하였습니다.

#### 리뷰 수정 버그  2deac0907255cc27fd6c9da3fc0065e028535f5c
- 리뷰를 수정할 때 기존 이미지 url을 프론트에서 넘겨주면 삭제하는 로직이 있습니다.
- 백엔드용 UI에서는 이미지가 입력으로 들어오지 않으면 emty list를 반환 해서 잘 작동하였습니다.
- 프론트에서 구현한 UI에서는 이미지 URL을 주지 않으면 null인 리스트를 반환해서 NPE 발생하였습니다.
- 따라서 list가 null일 경우 메서드를 early stop 하는 방식으로 버그를 수정하였습니다. 

### Issue Number

[LIME-111]

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-111]: https://uju-lime.atlassian.net/browse/LIME-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ