### PR TITLE
[NO-JIRA] 투표 랭킹 순위가 같을 경우, 투표 마감 시각이 빠른 순으로 정렬되도록 수정

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/application/VoteService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/application/VoteService.java
@@ -189,7 +189,7 @@ public class VoteService {
 		final Item item2 = itemReader.read(vote.getItem2Id());
 
 		return VoteRankingInfo.builder()
-			.id(vote.getId())
+			.id(Long.MAX_VALUE - vote.getId())
 			.item1Image(item1.getImage())
 			.item2Image(item2.getImage())
 			.build();

--- a/lime-infrastructure/src/main/java/com/programmers/lime/redis/vote/VoteRankingInfo.java
+++ b/lime-infrastructure/src/main/java/com/programmers/lime/redis/vote/VoteRankingInfo.java
@@ -12,7 +12,7 @@ public record VoteRankingInfo(
 	int participants
 ) {
 	public static VoteRankingInfo from(final ZSetOperations.TypedTuple<Object> typedTuple) {
-		final Long id = ((VoteRankingInfo)typedTuple.getValue()).id();
+		final Long id = Long.MAX_VALUE - ((VoteRankingInfo)typedTuple.getValue()).id();
 		final String item1Image = ((VoteRankingInfo)typedTuple.getValue()).item1Image();
 		final String item2Image = ((VoteRankingInfo)typedTuple.getValue()).item2Image();
 		final int participants = typedTuple.getScore().intValue();


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 기능 설명

#### 추가 요구사항 
- 투표 랭킹을 조회할 때, 동점 순위에 대해서는 투표 마감 임박순(=투표 마감 시각이 더 빠른 순)으로 정렬

#### 구현 방식
- 투표 id가 더 낮을수록 투표 마감 시각이 더 빠르기 때문에, 낮은 투표 Id가 더 높은 값을 가지도록 하기 위해서 Long의 최댓값에서 뺀 값을 저장하도록 하였습니다.
- 투표 마감 임박에 대해서, 최대 투표 인원 수가 다 차기 직전인 투표까지 고려하기엔 너무 복잡한 관계로 투표 마감 시각에 대해서만 고려하였습니다.

https://github.com/Yiseull/dev-qna/issues/9

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
