### PR TITLE
[NO-JIRA] 아이템 검색 기능 변경

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
@@ -69,7 +69,7 @@ public class ItemController {
 	@Operation(summary = "아이템 목록조회", description = "키워드, 취미를 이용하여 아이템 목록조회 합니다.")
 	@GetMapping("/search")
 	public ResponseEntity<ItemGetByCursorResponse> getItemsByCursor(
-		@RequestParam final String keyword,
+		@RequestParam(required = false) final String keyword,
 		@ModelAttribute("request") @Valid final CursorRequest request,
 		@RequestParam(required = false) final String itemSortCondition,
 		@RequestParam(required = false) final String hobbyName

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/ItemController.java
@@ -1,5 +1,6 @@
 package com.programmers.lime.domains.item.api;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.lime.domains.item.api.dto.request.ItemEnrollRequest;
+import com.programmers.lime.domains.item.api.dto.request.ItemSearchRequest;
 import com.programmers.lime.domains.item.api.dto.response.ItemEnrollResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetByCursorResponse;
 import com.programmers.lime.domains.item.api.dto.response.ItemGetNamesResponse;
@@ -69,16 +71,14 @@ public class ItemController {
 	@Operation(summary = "아이템 목록조회", description = "키워드, 취미를 이용하여 아이템 목록조회 합니다.")
 	@GetMapping("/search")
 	public ResponseEntity<ItemGetByCursorResponse> getItemsByCursor(
-		@RequestParam(required = false) final String keyword,
-		@ModelAttribute("request") @Valid final CursorRequest request,
-		@RequestParam(required = false) final String itemSortCondition,
-		@RequestParam(required = false) final String hobbyName
+		@ParameterObject @ModelAttribute("request") @Valid final CursorRequest request,
+		@ParameterObject @ModelAttribute @Valid final ItemSearchRequest searchRequest
 	) {
 		ItemGetByCursorServiceResponse serviceResponse = itemService.getItemsByCursor(
-			keyword,
+			searchRequest.keyword(),
 			request.toParameters(),
-			itemSortCondition,
-			hobbyName
+			searchRequest.itemSortCondition(),
+			searchRequest.hobbyName()
 		);
 		ItemGetByCursorResponse response = ItemGetByCursorResponse.from(serviceResponse);
 

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/dto/request/ItemSearchRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/dto/request/ItemSearchRequest.java
@@ -1,0 +1,21 @@
+package com.programmers.lime.domains.item.api.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ItemSearchRequest (
+
+	@Schema(description = "검색어", example = "농구")
+	@Length(max = 100)
+	String keyword,
+
+	@Schema(description = "아이템 검색 조건", example = "REVIEW_COUNT_DESC")
+	@Length(max = 50)
+	String itemSortCondition,
+
+	@Schema(description = "취미 이름", example = "데스크테리어")
+	@Length(max = 20)
+	String hobbyName
+){
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/api/dto/response/ItemGetByCursorResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/api/dto/response/ItemGetByCursorResponse.java
@@ -8,7 +8,7 @@ import com.programmers.lime.domains.item.model.ItemCursorSummary;
 
 public record ItemGetByCursorResponse(
 	String nextCursorId,
-	int itemTotalCount,
+	Long itemTotalCount,
 	int totalCount,
 	List<ItemCursorSummary> items
 ) {

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/application/ItemService.java
@@ -101,7 +101,7 @@ public class ItemService {
 		);
 
 		// 요청한 조건에 해당하는 모든 아이템의 수를 itemTotalCount에 저장
-		int itemTotalCount = itemReader.getItemTotalCountByKeyword(keyword, hobby);
+		Long itemTotalCount = itemReader.getItemTotalCountByKeyword(keyword, hobby);
 
 		return new ItemGetByCursorServiceResponse(
 			itemTotalCount,

--- a/lime-api/src/main/java/com/programmers/lime/domains/item/application/dto/ItemGetByCursorServiceResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/item/application/dto/ItemGetByCursorServiceResponse.java
@@ -5,7 +5,7 @@ import com.programmers.lime.domains.item.model.ItemCursorSummary;
 
 public record ItemGetByCursorServiceResponse(
 
-	int itemTotalCount,
+	Long itemTotalCount,
 	CursorSummary<ItemCursorSummary> cursorSummary
 ) {
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/bucket/implementation/BucketAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/bucket/implementation/BucketAppender.java
@@ -1,7 +1,6 @@
 package com.programmers.lime.domains.bucket.implementation;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +11,6 @@ import com.programmers.lime.domains.bucket.domain.BucketInfo;
 import com.programmers.lime.domains.bucket.domain.BucketItem;
 import com.programmers.lime.domains.bucket.repository.BucketItemRepository;
 import com.programmers.lime.domains.bucket.repository.BucketRepository;
-import com.programmers.lime.domains.item.domain.Item;
 import com.programmers.lime.domains.item.implementation.ItemReader;
 import com.programmers.lime.error.BusinessException;
 import com.programmers.lime.error.ErrorCode;

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemCursorReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemCursorReader.java
@@ -41,20 +41,9 @@ public class ItemCursorReader {
 		final ItemSortCondition itemSortCondition,
 		final Hobby hobby
 	) {
-		String trimmedKeyword = keyword.trim();
-
-		// 비어 있는 키워드일 경우 빈 리스트 반환
-		if (trimmedKeyword.isEmpty()) {
-			return new CursorSummary<>(
-				null,
-				0,
-				Collections.emptyList()
-			);
-		}
-
 		// 키워드에 해당하는 아이템 아이디와 커서 아이디를 가져옴
 		List<ItemCursorIdInfo> itemCursorIdInfos = itemRepository.getItemIdsByCursor(
-			trimmedKeyword,
+			keyword,
 			parameters.cursorId(),
 			getPageSize(parameters),
 			itemSortCondition,

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/ItemReader.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.programmers.lime.common.model.Hobby;
 import com.programmers.lime.domains.inventory.model.InventoryReviewItemSummary;
 import com.programmers.lime.domains.item.domain.Item;
+import com.programmers.lime.domains.item.repository.ItemCustomRepository;
 import com.programmers.lime.domains.item.repository.ItemRepository;
 import com.programmers.lime.error.EntityNotFoundException;
 import com.programmers.lime.error.ErrorCode;
@@ -20,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 public class ItemReader {
 
 	private final ItemRepository itemRepository;
+
+	private final ItemCustomRepository itemCustomRepository;
 
 	public Item read(final Long itemId) {
 		return itemRepository.findById(itemId)
@@ -46,16 +49,6 @@ public class ItemReader {
 		return itemRepository.existsItemsByUrl(itemURL);
 	}
 
-	public int getItemTotalCountByKeyword(final String keyword, final Hobby hobby) {
-		String trimmedKeyword = keyword.trim();
-
-		if (trimmedKeyword.isEmpty()) {
-			return 0;
-		}
-
-		return itemRepository.countItemByKeywordAndHobby(trimmedKeyword, hobby);
-	}
-
 	public boolean doesNotExist(final Long itemId) {
 		return !itemRepository.existsById(itemId);
   }
@@ -66,5 +59,9 @@ public class ItemReader {
 
 	public List<Item> readAll(final List<Long> itemIds) {
 		return itemRepository.findAllByIdIn(itemIds);
+	}
+
+	public Long getItemTotalCountByKeyword(final String keyword, final Hobby hobby) {
+		return itemCustomRepository.countItem(keyword, hobby);
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemCustomRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemCustomRepository.java
@@ -1,0 +1,8 @@
+package com.programmers.lime.domains.item.repository;
+
+import com.programmers.lime.common.model.Hobby;
+
+public interface ItemCustomRepository {
+
+	Long countItem(String keyword, Hobby hobby);
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemCustomRepositoryImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemCustomRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.programmers.lime.domains.item.repository;
+
+
+import static com.programmers.lime.domains.item.domain.QItem.*;
+
+import org.springframework.stereotype.Repository;
+
+import com.programmers.lime.common.model.Hobby;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemCustomRepositoryImpl implements ItemCustomRepository{
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Long countItem(final String keyword, final Hobby hobby) {
+		return jpaQueryFactory.selectFrom(item)
+			.where(
+				eqName(keyword),
+				eqHobby(hobby)
+			).fetchCount();
+	}
+
+	private BooleanExpression eqName(final String keyword) {
+		return keyword != null ? item.name.contains(keyword) : null;
+	}
+
+	private BooleanExpression eqHobby(final Hobby hobby) {
+		return hobby != null ? item.hobby.eq(hobby) : null;
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/repository/ItemRepositoryForCursorImpl.java
@@ -53,13 +53,17 @@ public class ItemRepositoryForCursorImpl implements ItemRepositoryForCursor {
 			).from(item)
 			.where(
 				cursorIdCondition(cursorId),
-				item.name.contains(keyword),
+				eqKeyword(keyword),
 				hobbyCondition(hobby)
 			).orderBy(orderBySortCondition(itemSortCondition), item.id.desc())
 			.groupBy(item.id)
 			.leftJoin(review).on(item.id.eq(review.itemId))
 			.limit(pageSize)
 			.fetch();
+	}
+
+	private BooleanExpression eqKeyword(final String keyword) {
+		return keyword != null ? item.name.contains(keyword) : null;
 	}
 
 	@Override


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
#### 아이템 검색할 때 keyword를 입력하지 않아도 조회될 수 있도록 기능 변경하였습니다. e5b92cb3fda26b7986920df690f442d05939136d
- keyword, hobby에 따라 전체 아이템수를 다르게 반환해야 해서 이부분은 query dsl로 만들었습니다.
- 전체 아이템 수를 Long으로 변경한 이유
  - query dsl에서는 fetch count를 사용해야하는데 기본적으로 Long을 반환 합니다.
  - Long을 integer로 repository에서 변경 가능하지만 이렇게 되면 예외처리와 변환 할 때 추가적인 비용이 필요합니다.
  - 백엔드에서 이 값으로 int와 연산을 하지 않고 프론트에서는 number로 받고 있어서 int, Long 반환 값의 차이는 없다고 생각합니다.
  - 그래서 총 아이템수를 반환하는 dto의 타입을 Long으로 수정하였습니다. 

### Issue Number

[NO-JIRA]

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
