### PR TITLE
[LIME-107] transactional이 readonly로 인해 폴더가 생성되지 않는 버그 수정

### DIFF
--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderReader.java
@@ -42,6 +42,7 @@ public class MemberItemFolderReader {
 		return memberItemFolderRepository.getIdByMemberIdAndName(memberId, folderName);
 	}
 
+	@Transactional
 	public Long getDefaultFolderId(final Long memberId, final String defaultFolderName) {
 		List<Long> folderIds = getIdByMemberIdAndName(memberId, defaultFolderName);
 


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
#### transactional이 readonly으로 인한 버그 수정  24ed277382b839548052cde5d9def36a1ce8ade3
- transactional이 readonly로 인해 폴더가 생성되지 생성되지 않는 버그가 있습니다.
- MemberItemFolderReader클래스의 getDefaultFolderId메서드와 MemberItemFolderAppender클래스의 append 메서드 두개 중에 transactional을 getDefaultFolderId 메서드에 붙였습니다.
- 이렇게 한 이유는 append메서드만 보면 transactional을 붙여야할 이유가 없습니다.
- 따라서 추후 유지보수 과정에서 transcational을 제거할 수 있고 이때 버그가 발생할 수 있다고 생각됩니다.
- 추가로 "@Transactional(readOnly = true) "으로 DB의 변경 가능성이 없다고 표시한 MemberItemFolderReader 클래스에 예외적으로 getDefaultFolderId메서드에는 변경될 수 있음을 표기하는게 맞다고 생각합니다.

### Issue Number

[LIME-107]

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-107]: https://uju-lime.atlassian.net/browse/LIME-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ