### PR TITLE
[LIME-119] 투표 통합 테스트 추가

### DIFF
--- a/lime-api/build.gradle
+++ b/lime-api/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     // 테스트 관련
     testImplementation(testFixtures(project(':lime-domain')))
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'com.h2database:h2'
 
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/lime-api/build.gradle
+++ b/lime-api/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     // 테스트 관련
     testImplementation(testFixtures(project(':lime-domain')))
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
 
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
@@ -95,7 +95,7 @@ public class VoteController {
 		@RequestParam final String hobby,
 		@RequestParam(required = false, name = "status") final String statusCondition,
 		@RequestParam(required = false, name = "sort") final String sortCondition,
-		@ModelAttribute @Valid final CursorRequest request
+		@ModelAttribute final CursorRequest request
 	) {
 		final CursorSummary<VoteSummary> cursorSummary = voteService.getVotesByCursor(
 			Hobby.from(hobby),
@@ -112,7 +112,7 @@ public class VoteController {
 	@GetMapping("/search")
 	public ResponseEntity<VoteGetByKeywordResponse> getVotesByKeyword(
 		@RequestParam final String keyword,
-		@ModelAttribute @Valid final CursorRequest request
+		@ModelAttribute final CursorRequest request
 	) {
 		final VoteGetByKeywordServiceResponse serviceResponse = voteService.getVotesByKeyword(keyword,
 			request.toParameters());

--- a/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
@@ -1,14 +1,17 @@
 package com.programmers.lime.global.cursor;
 
+import org.springdoc.core.annotations.ParameterObject;
+
 import com.programmers.lime.common.cursor.CursorPageParameters;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
 
+@ParameterObject
 public record CursorRequest(
-	@Schema(description = "커서아이디, 첫 조회는 커서아이디 없는 요청입니다.", example = "2023110124000001")
+	@Parameter(description = "커서아이디, 첫 조회는 커서아이디 없는 요청입니다.", example = "2023110124000001")
 	String cursorId,
 
-	@Schema(description = "페이징 사이즈입니다", example = "10")
+	@Parameter(description = "페이징 사이즈입니다", example = "10")
 	Integer size
 ) {
 	public CursorPageParameters toParameters() {

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -3,27 +3,41 @@ package com.programmers.lime.domains.vote.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.lime.IntegrationTest;
 import com.programmers.lime.common.model.Hobby;
 import com.programmers.lime.domains.item.domain.setup.ItemSetup;
 import com.programmers.lime.domains.vote.application.dto.request.VoteCreateServiceRequest;
+import com.programmers.lime.domains.vote.domain.Vote;
+import com.programmers.lime.domains.vote.domain.Voter;
+import com.programmers.lime.domains.vote.domain.setup.VoteSetUp;
+import com.programmers.lime.domains.vote.domain.setup.VoterSetUp;
 import com.programmers.lime.error.BusinessException;
 import com.programmers.lime.error.EntityNotFoundException;
 import com.programmers.lime.error.ErrorCode;
 import com.programmers.lime.global.util.MemberUtils;
+import com.programmers.lime.redis.vote.VoteRankingInfo;
 import com.programmers.lime.redis.vote.VoteRedisManager;
 
 class VoteServiceTest extends IntegrationTest {
 
 	@Autowired
 	private VoteService voteService;
+
+	@Autowired
+	private VoteSetUp voteSetup;
+
+	@Autowired
+	private VoterSetUp voterSetup;
 
 	@Autowired
 	private ItemSetup itemSetup;
@@ -110,6 +124,100 @@ class VoteServiceTest extends IntegrationTest {
 				.isInstanceOf(EntityNotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ITEM_NOT_FOUND);
 
+			then(voteRedisManager).shouldHaveNoInteractions();
+		}
+	}
+
+	@Transactional // 지연 로딩을 위해 필요
+	@Nested
+	class ParticipateVote {
+		@Test
+		@DisplayName("투표에 참여한다.")
+		void participateVoteTest() {
+			// given
+			final Long voteId = 1L;
+			final Long itemId = 1L;
+			final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			willDoNothing()
+				.given(voteRedisManager)
+				.updateRanking(eq(String.valueOf(vote.getHobby())), eq(true), any(VoteRankingInfo.class));
+
+			// when
+			voteService.participateVote(voteId, itemId);
+
+			// then
+			assertThat(vote.getVoters()).hasSize(1);
+
+			// verify
+			then(voteRedisManager).should(times(1))
+				.updateRanking(eq(String.valueOf(vote.getHobby())), eq(true), any(VoteRankingInfo.class));
+		}
+
+		@Test
+		@DisplayName("투표에 재참여한다.")
+		void reParticipateVoteTest() {
+			// given
+			final Long voteId = 1L;
+			final Long itemId = 2L;
+			final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
+			final Voter voter = voterSetup.saveOne(vote, 1L, 1L);
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			// when
+			voteService.participateVote(voteId, itemId);
+
+			// then
+			assertThat(vote.getVoters()).hasSize(1);
+			assertThat(voter.getItemId()).isEqualTo(itemId);
+
+			// verify
+			then(voteRedisManager).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("종료된 투표에 참여하려고 하면 예외를 발생시킨다.")
+		void participateVoteWithEndedVoteTest() {
+			// given
+			final Long voteId = 1L;
+			final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
+
+			vote.close(LocalDateTime.now());
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			// when & then
+			assertThatThrownBy(() -> voteService.participateVote(voteId, 1L))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.VOTE_CANNOT_PARTICIPATE);
+
+			// verify
+			then(voteRedisManager).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("투표에 없는 아이템에 참여하려고 하면 예외를 발생시킨다.")
+		void participateVoteWithNotExistItemTest() {
+			// given
+			final Long voteId = 1L;
+			final Long itemId = 3L;
+			voteSetup.saveOne(voteId, 1L, 2L);
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			// when & then
+			assertThatThrownBy(() -> voteService.participateVote(voteId, itemId))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.VOTE_NOT_CONTAIN_ITEM);
+
+			// verify
 			then(voteRedisManager).shouldHaveNoInteractions();
 		}
 	}

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -228,4 +228,30 @@ class VoteServiceTest extends IntegrationTest {
 			then(voteRedisManager).shouldHaveNoInteractions();
 		}
 	}
+
+	@Test
+	@DisplayName("투표 참여를 취소할 수 있다.")
+	void cancelVoteTest() {
+		// given
+		final Long voteId = 1L;
+		final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
+		voterSetup.saveOne(vote, 1L, 1L);
+
+		given(memberUtils.getCurrentMemberId())
+			.willReturn(1L);
+
+		willDoNothing()
+			.given(voteRedisManager)
+			.decreasePopularity(eq(String.valueOf(vote.getHobby())), any(VoteRankingInfo.class));
+
+		// when
+		voteService.cancelVote(voteId);
+
+		// then
+		assertThat(vote.getVoters()).isEmpty();
+
+		// verify
+		then(voteRedisManager).should(times(1))
+			.decreasePopularity(eq(String.valueOf(vote.getHobby())), any(VoteRankingInfo.class));
+	}
 }

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -21,6 +21,7 @@ import com.programmers.lime.domains.item.domain.Item;
 import com.programmers.lime.domains.item.domain.setup.ItemSetup;
 import com.programmers.lime.domains.item.model.ItemInfo;
 import com.programmers.lime.domains.vote.application.dto.request.VoteCreateServiceRequest;
+import com.programmers.lime.domains.vote.application.dto.response.VoteGetByKeywordServiceResponse;
 import com.programmers.lime.domains.vote.application.dto.response.VoteGetServiceResponse;
 import com.programmers.lime.domains.vote.domain.Vote;
 import com.programmers.lime.domains.vote.domain.Voter;
@@ -552,6 +553,60 @@ class VoteServiceTest extends IntegrationTest {
 			))
 				.isInstanceOf(BusinessException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED);
+		}
+	}
+
+	@Nested
+	class GetVotesByKeyword {
+
+		Vote vote2;
+
+		@BeforeEach
+		void setUp() {
+			vote2 = voteSetup.save(Vote.builder()
+				.memberId(1L)
+				.item1Id(item1.getId())
+				.item2Id(item2.getId())
+				.hobby(Hobby.BASKETBALL)
+				.content("농린이 추천템은?")
+				.maximumParticipants(1000)
+				.build());
+		}
+
+		@Test
+		@DisplayName("사용자는 투표 아이템명에 키워드가 포함된 투표 목록을 조회할 수 있다.")
+		void getVotesByItemNameTest() {
+			// given
+			final String keyword = item1.getName();
+
+			// when
+			final VoteGetByKeywordServiceResponse result = voteService.getVotesByKeyword(
+				keyword,
+				new CursorPageParameters(null, 1)
+			);
+
+			// then
+			assertThat(result.voteSummary().summaryCount()).isEqualTo(1);
+			assertThat(result.voteSummary().summaries().get(0).voteInfo().id()).isEqualTo(vote2.getId());
+			assertThat(result.totalVoteCount()).isEqualTo(2);
+		}
+
+		@Test
+		@DisplayName("사용자는 투표 제목에 키워드가 포함된 투표 목록을 조회할 수 있다.")
+		void getVotesByTitleTest() {
+			// given
+			final String keyword = "농린이";
+
+			// when
+			final VoteGetByKeywordServiceResponse result = voteService.getVotesByKeyword(
+				keyword,
+				new CursorPageParameters(null, 1)
+			);
+
+			// then
+			assertThat(result.voteSummary().summaryCount()).isEqualTo(1);
+			assertThat(result.voteSummary().summaries().get(0).voteInfo().id()).isEqualTo(vote2.getId());
+			assertThat(result.totalVoteCount()).isEqualTo(1);
 		}
 	}
 }

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -1,0 +1,116 @@
+package com.programmers.lime.domains.vote.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.programmers.lime.IntegrationTest;
+import com.programmers.lime.common.model.Hobby;
+import com.programmers.lime.domains.item.domain.setup.ItemSetup;
+import com.programmers.lime.domains.vote.application.dto.request.VoteCreateServiceRequest;
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.EntityNotFoundException;
+import com.programmers.lime.error.ErrorCode;
+import com.programmers.lime.global.util.MemberUtils;
+import com.programmers.lime.redis.vote.VoteRedisManager;
+
+class VoteServiceTest extends IntegrationTest {
+
+	@Autowired
+	private VoteService voteService;
+
+	@Autowired
+	private ItemSetup itemSetup;
+
+	@MockBean
+	private MemberUtils memberUtils;
+
+	@MockBean
+	private VoteRedisManager voteRedisManager;
+
+	@BeforeEach
+	void setUp() {
+		itemSetup.saveOne(1L);
+		itemSetup.saveOne(2L);
+	}
+
+	@Nested
+	class CreateVote {
+		@Test
+		@DisplayName("투표를 생성한다.")
+		void createVoteTest() {
+			// given
+			final VoteCreateServiceRequest request = VoteCreateServiceRequest.builder()
+				.hobby(Hobby.BASKETBALL)
+				.content("농구공 추천 좀 해주세요!")
+				.item1Id(1L)
+				.item2Id(2L)
+				.maximumParticipants(1000)
+				.build();
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			willDoNothing()
+				.given(voteRedisManager).addRanking(any(), any());
+
+			// when
+			final Long result = voteService.createVote(request);
+
+			// then
+			assertThat(result).isNotNull();
+		}
+
+		@Test
+		@DisplayName("투표 아이템이 똑같다면 예외를 발생시킨다.")
+		void createVoteWithSameItemTest() {
+			// given
+			final VoteCreateServiceRequest request = VoteCreateServiceRequest.builder()
+				.hobby(Hobby.BASKETBALL)
+				.content("농구공 추천 좀 해주세요!")
+				.item1Id(1L)
+				.item2Id(1L)
+				.maximumParticipants(1000)
+				.build();
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			// when & then
+			assertThatThrownBy(() -> voteService.createVote(request))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.VOTE_ITEM_DUPLICATED);
+
+			then(voteRedisManager).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("투표 아이템이 존재하지 않는다면 예외를 발생시킨다.")
+		void createVoteWithNotExistItemTest() {
+			// given
+			final VoteCreateServiceRequest request = VoteCreateServiceRequest.builder()
+				.hobby(Hobby.BASKETBALL)
+				.content("농구공 추천 좀 해주세요!")
+				.item1Id(3L)
+				.item2Id(4L)
+				.maximumParticipants(1000)
+				.build();
+
+			given(memberUtils.getCurrentMemberId())
+				.willReturn(1L);
+
+			// when & then
+			assertThatThrownBy(() -> voteService.createVote(request))
+				.isInstanceOf(EntityNotFoundException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ITEM_NOT_FOUND);
+
+			then(voteRedisManager).shouldHaveNoInteractions();
+		}
+	}
+}

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -346,8 +346,7 @@ class VoteServiceTest extends IntegrationTest {
 	@Nested
 	class RaadVote {
 		@Test
-		@DisplayName("사용자는 투표를 상세 조회할 수 있다.")
-			// 사용자는 회원과 비회원을 모두 의미
+		@DisplayName("사용자는 투표를 상세 조회할 수 있다.") // 사용자는 회원과 비회원을 모두 의미
 		void readVoteTest() {
 			// when
 			final VoteGetServiceResponse result = voteService.getVote(voteId);

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -57,7 +57,7 @@ class VoteServiceTest extends IntegrationTest {
 	@Nested
 	class CreateVote {
 		@Test
-		@DisplayName("투표를 생성한다.")
+		@DisplayName("투표를 생성할 수 있다.")
 		void createVoteTest() {
 			// given
 			final VoteCreateServiceRequest request = VoteCreateServiceRequest.builder()
@@ -82,7 +82,7 @@ class VoteServiceTest extends IntegrationTest {
 		}
 
 		@Test
-		@DisplayName("투표 아이템이 똑같다면 예외를 발생시킨다.")
+		@DisplayName("동일한 투표 아이템으로 투표를 생성할 수 없다.")
 		void createVoteWithSameItemTest() {
 			// given
 			final VoteCreateServiceRequest request = VoteCreateServiceRequest.builder()
@@ -105,7 +105,7 @@ class VoteServiceTest extends IntegrationTest {
 		}
 
 		@Test
-		@DisplayName("투표 아이템이 존재하지 않는다면 예외를 발생시킨다.")
+		@DisplayName("존재하지 않는 아이템으로 투표를 생성할 수 없다.")
 		void createVoteWithNotExistItemTest() {
 			// given
 			final VoteCreateServiceRequest request = VoteCreateServiceRequest.builder()
@@ -141,7 +141,7 @@ class VoteServiceTest extends IntegrationTest {
 		}
 
 		@Test
-		@DisplayName("투표에 참여한다.")
+		@DisplayName("투표에 참여할 수 있다.")
 		void participateVoteTest() {
 			// given
 			final Long itemId = 1L;
@@ -165,7 +165,7 @@ class VoteServiceTest extends IntegrationTest {
 		}
 
 		@Test
-		@DisplayName("투표에 재참여한다.")
+		@DisplayName("이미 참여한 투표에 다시 참여할 수 있다.")
 		void reParticipateVoteTest() {
 			// given
 			final Long itemId = 2L;
@@ -186,8 +186,8 @@ class VoteServiceTest extends IntegrationTest {
 		}
 
 		@Test
-		@DisplayName("종료된 투표에 참여하려고 하면 예외를 발생시킨다.")
-		void participateVoteWithEndedVoteTest() {
+		@DisplayName("종료된 투표에 참여할 수 없다.")
+		void participateVoteWithClosedVoteTest() {
 			// given
 			vote.close(LocalDateTime.now());
 
@@ -204,7 +204,7 @@ class VoteServiceTest extends IntegrationTest {
 		}
 
 		@Test
-		@DisplayName("투표에 없는 아이템에 참여하려고 하면 예외를 발생시킨다.")
+		@DisplayName("투표에 없는 아이템으로 참여할 수 없다.")
 		void participateVoteWithNotExistItemTest() {
 			// given
 			final Long itemId = 3L;

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -17,12 +17,15 @@ import com.programmers.lime.IntegrationTest;
 import com.programmers.lime.common.model.Hobby;
 import com.programmers.lime.domains.item.domain.Item;
 import com.programmers.lime.domains.item.domain.setup.ItemSetup;
+import com.programmers.lime.domains.item.model.ItemInfo;
 import com.programmers.lime.domains.vote.application.dto.request.VoteCreateServiceRequest;
+import com.programmers.lime.domains.vote.application.dto.response.VoteGetServiceResponse;
 import com.programmers.lime.domains.vote.domain.Vote;
 import com.programmers.lime.domains.vote.domain.Voter;
 import com.programmers.lime.domains.vote.domain.setup.VoteSetUp;
 import com.programmers.lime.domains.vote.domain.setup.VoterSetUp;
 import com.programmers.lime.domains.vote.implementation.VoteReader;
+import com.programmers.lime.domains.vote.model.VoteDetailInfo;
 import com.programmers.lime.error.BusinessException;
 import com.programmers.lime.error.EntityNotFoundException;
 import com.programmers.lime.error.ErrorCode;
@@ -338,5 +341,17 @@ class VoteServiceTest extends IntegrationTest {
 			// verify
 			then(voteRedisManager).shouldHaveNoInteractions();
 		}
+	}
+
+	@Test
+	@DisplayName("사용자는 투표를 상세 조회할 수 있다.")
+	void readVoteTest() {
+		// when
+		final VoteGetServiceResponse result = voteService.getVote(voteId);
+
+		// then
+		assertThat(result.item1Info()).isEqualTo(ItemInfo.from(item1));
+		assertThat(result.item2Info()).isEqualTo(ItemInfo.from(item2));
+		assertThat(result.voteInfo()).isEqualTo(VoteDetailInfo.of(vote, 0, 0));
 	}
 }

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -131,13 +131,20 @@ class VoteServiceTest extends IntegrationTest {
 	@Transactional // 지연 로딩을 위해 필요
 	@Nested
 	class ParticipateVote {
+
+		Long voteId = 1L;
+		Vote vote;
+
+		@BeforeEach
+		void setUp() {
+			vote = voteSetup.saveOne(voteId, 1L, 2L);
+		}
+
 		@Test
 		@DisplayName("투표에 참여한다.")
 		void participateVoteTest() {
 			// given
-			final Long voteId = 1L;
 			final Long itemId = 1L;
-			final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
 
 			given(memberUtils.getCurrentMemberId())
 				.willReturn(1L);
@@ -161,9 +168,7 @@ class VoteServiceTest extends IntegrationTest {
 		@DisplayName("투표에 재참여한다.")
 		void reParticipateVoteTest() {
 			// given
-			final Long voteId = 1L;
 			final Long itemId = 2L;
-			final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
 			final Voter voter = voterSetup.saveOne(vote, 1L, 1L);
 
 			given(memberUtils.getCurrentMemberId())
@@ -184,9 +189,6 @@ class VoteServiceTest extends IntegrationTest {
 		@DisplayName("종료된 투표에 참여하려고 하면 예외를 발생시킨다.")
 		void participateVoteWithEndedVoteTest() {
 			// given
-			final Long voteId = 1L;
-			final Vote vote = voteSetup.saveOne(voteId, 1L, 2L);
-
 			vote.close(LocalDateTime.now());
 
 			given(memberUtils.getCurrentMemberId())
@@ -205,9 +207,7 @@ class VoteServiceTest extends IntegrationTest {
 		@DisplayName("투표에 없는 아이템에 참여하려고 하면 예외를 발생시킨다.")
 		void participateVoteWithNotExistItemTest() {
 			// given
-			final Long voteId = 1L;
 			final Long itemId = 3L;
-			voteSetup.saveOne(voteId, 1L, 2L);
 
 			given(memberUtils.getCurrentMemberId())
 				.willReturn(1L);

--- a/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
+++ b/lime-api/src/test/java/com/programmers/lime/domains/vote/application/VoteServiceTest.java
@@ -72,13 +72,18 @@ class VoteServiceTest extends IntegrationTest {
 				.willReturn(1L);
 
 			willDoNothing()
-				.given(voteRedisManager).addRanking(any(), any());
+				.given(voteRedisManager)
+				.addRanking(String.valueOf(Hobby.BASKETBALL), any(VoteRankingInfo.class));
 
 			// when
 			final Long result = voteService.createVote(request);
 
 			// then
 			assertThat(result).isNotNull();
+
+			// verify
+			then(voteRedisManager).should(times(1))
+				.addRanking(String.valueOf(Hobby.BASKETBALL), any(VoteRankingInfo.class));
 		}
 
 		@Test
@@ -101,6 +106,7 @@ class VoteServiceTest extends IntegrationTest {
 				.isInstanceOf(BusinessException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.VOTE_ITEM_DUPLICATED);
 
+			// verify
 			then(voteRedisManager).shouldHaveNoInteractions();
 		}
 
@@ -124,6 +130,7 @@ class VoteServiceTest extends IntegrationTest {
 				.isInstanceOf(EntityNotFoundException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ITEM_NOT_FOUND);
 
+			// verify
 			then(voteRedisManager).shouldHaveNoInteractions();
 		}
 	}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -134,7 +134,7 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 
 		final List<Long> itemIds = getItemIds(keyword);
 
-		return vote.item1Id.in(itemIds).or(vote.item2Id.in(itemIds));
+		return vote.item1Id.in(itemIds).or(vote.item2Id.in(itemIds)).or(vote.content.content.contains(keyword));
 	}
 
 	private List<Long> getItemIds(final String keyword) {

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -3,7 +3,6 @@ package com.programmers.lime.domains.vote.repository;
 import static com.programmers.lime.domains.item.domain.QItem.*;
 import static com.programmers.lime.domains.vote.domain.QVote.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import com.programmers.lime.common.model.Hobby;
@@ -69,10 +68,7 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 		return jpaQueryFactory
 			.select(vote.count())
 			.from(vote)
-			.where(
-				isCompleted(),
-				containsKeyword(keyword)
-			)
+			.where(containsKeyword(keyword))
 			.fetchOne();
 	}
 
@@ -103,10 +99,6 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 				return null;
 			}
 		}
-	}
-
-	private BooleanExpression isCompleted() {
-		return vote.endTime.before(LocalDateTime.now());
 	}
 
 	private BooleanExpression isPosted(final Long memberId) {

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/VoteBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/VoteBuilder.java
@@ -31,6 +31,24 @@ public class VoteBuilder {
 		return vote;
 	}
 
+	public static Vote build(
+		final Long voteId,
+		final Long item1Id,
+		final Long item2Id
+	) {
+		final Vote vote = Vote.builder()
+			.memberId(1L)
+			.item1Id(item1Id)
+			.item2Id(item2Id)
+			.hobby(Hobby.BASKETBALL)
+			.content("농구공 사려는데 뭐가 더 좋음?")
+			.maximumParticipants(3)
+			.build();
+		setVoteId(vote, voteId);
+
+		return vote;
+	}
+
 	public static List<Vote> buildMany(final int size) {
 		final List<Vote> votes = new ArrayList<>();
 		for (int i = 0; i < size; i++) {

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/setup/VoteSetUp.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/setup/VoteSetUp.java
@@ -1,0 +1,26 @@
+package com.programmers.lime.domains.vote.domain.setup;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.vote.domain.Vote;
+import com.programmers.lime.domains.vote.domain.VoteBuilder;
+import com.programmers.lime.domains.vote.repository.VoteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class VoteSetUp {
+
+	private final VoteRepository voteRepository;
+
+	public Vote saveOne(
+		final Long voteId,
+		final Long item1Id,
+		final Long item2Id
+	) {
+		final Vote vote = VoteBuilder.build(voteId, item1Id, item2Id);
+
+		return voteRepository.save(vote);
+	}
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/setup/VoteSetUp.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/setup/VoteSetUp.java
@@ -23,4 +23,8 @@ public class VoteSetUp {
 
 		return voteRepository.save(vote);
 	}
+
+	public Vote save(final Vote vote) {
+		return voteRepository.save(vote);
+	}
 }

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/setup/VoterSetUp.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/vote/domain/setup/VoterSetUp.java
@@ -1,0 +1,27 @@
+package com.programmers.lime.domains.vote.domain.setup;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.vote.domain.Vote;
+import com.programmers.lime.domains.vote.domain.Voter;
+import com.programmers.lime.domains.vote.repository.VoterRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class VoterSetUp {
+
+	private final VoterRepository voterRepository;
+
+	public Voter saveOne(
+		final Vote vote,
+		final Long memberId,
+		final Long itemId
+	) {
+		final Voter voter = new Voter(vote, memberId, itemId);
+
+		return voterRepository.save(voter);
+
+	}
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [X]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME-119

### 💡 테스트 설명
- 테스트명은 기능 명세서와 같이 작성하였습니다. 그 이유는 저희 서비스가 비지니스 명세 역할을 하고 있기도 하고, 테스트 코드가 기능 명세 역할 한다는 이야기를 들은 적이 있어서 이렇게 작성하였습니다.
- 각각 기능에 대해 가능한 모든 시나리오에 대해 테스트를 작성하였습니다. 그 이유는 추후 리팩토링이나 기능 변경이 있을 경우 테스트로 빠르게 확인하기 위함입니다.
- 투표 검색 테스트는 투표 검색 기능에 대해 의논이 끝난 후 추가 작성해서 올리겠습니다!

### 💡 H2 의존성을 추가했다가 다시 제거한 이유
- 현재 로컬 DB를 이용해서 테스트를 진행해야 합니다. 그래서 테스트만을 위한 독립적인 DB를 구성하기 위해 H2를 사용하고자 했으나, H2에는 MySQL의 DATE_FORMAT 함수를 대체할 수 있는 함수가 없어서 목록 조회 테스트에서 실패합니다.
- 이를 해결하고자, DATE_FORMAT을 사용자 정의 함수로 만들어서 H2에 올리는 방법을 시도해보았으나 실패하여서 일단 H2 의존성을 다시 제거하였습니다😭
- 여유가 있을 때 위의 방법을 다시 시도해볼 생각입니다! 다같이 더 나은 방법이 없는지 찾아봐도 좋을 것 같습니다😊

### 💡 투표 참여 테스트에 `@Transactional`을 붙인 이유
- 아래 문서에 정리해놓았으니 참고해주세용!!
[@SpringBootTest 에서 LazyInitializationException 트러블슈팅](https://github.com/Yiseull/dev-qna/blob/main/%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85/%40SpringBootTest%20%EC%97%90%EC%84%9C%20LazyInitializationException%20%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85.md)

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
