### PR TITLE
[NO-JIRA] fix vote keyword

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
@@ -95,7 +95,7 @@ public class VoteController {
 		@RequestParam final String hobby,
 		@RequestParam(required = false, name = "status") final String statusCondition,
 		@RequestParam(required = false, name = "sort") final String sortCondition,
-		@ModelAttribute @Valid final CursorRequest request
+		@ModelAttribute final CursorRequest request
 	) {
 		final CursorSummary<VoteSummary> cursorSummary = voteService.getVotesByCursor(
 			Hobby.from(hobby),
@@ -112,7 +112,7 @@ public class VoteController {
 	@GetMapping("/search")
 	public ResponseEntity<VoteGetByKeywordResponse> getVotesByKeyword(
 		@RequestParam final String keyword,
-		@ModelAttribute @Valid final CursorRequest request
+		@ModelAttribute final CursorRequest request
 	) {
 		final VoteGetByKeywordServiceResponse serviceResponse = voteService.getVotesByKeyword(keyword,
 			request.toParameters());

--- a/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/cursor/CursorRequest.java
@@ -1,14 +1,17 @@
 package com.programmers.lime.global.cursor;
 
+import org.springdoc.core.annotations.ParameterObject;
+
 import com.programmers.lime.common.cursor.CursorPageParameters;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
 
+@ParameterObject
 public record CursorRequest(
-	@Schema(description = "커서아이디, 첫 조회는 커서아이디 없는 요청입니다.", example = "2023110124000001")
+	@Parameter(description = "커서아이디, 첫 조회는 커서아이디 없는 요청입니다.", example = "2023110124000001")
 	String cursorId,
 
-	@Schema(description = "페이징 사이즈입니다", example = "10")
+	@Parameter(description = "페이징 사이즈입니다", example = "10")
 	Integer size
 ) {
 	public CursorPageParameters toParameters() {

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -134,7 +134,7 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 
 		final List<Long> itemIds = getItemIds(keyword);
 
-		return vote.item1Id.in(itemIds).or(vote.item2Id.in(itemIds));
+		return vote.item1Id.in(itemIds).or(vote.item2Id.in(itemIds)).or(vote.content.content.contains(keyword));
 	}
 
 	private List<Long> getItemIds(final String keyword) {

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -3,7 +3,6 @@ package com.programmers.lime.domains.vote.repository;
 import static com.programmers.lime.domains.item.domain.QItem.*;
 import static com.programmers.lime.domains.vote.domain.QVote.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import com.programmers.lime.common.model.Hobby;
@@ -69,10 +68,7 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 		return jpaQueryFactory
 			.select(vote.count())
 			.from(vote)
-			.where(
-				isCompleted(),
-				containsKeyword(keyword)
-			)
+			.where(containsKeyword(keyword))
 			.fetchOne();
 	}
 
@@ -103,10 +99,6 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 				return null;
 			}
 		}
-	}
-
-	private BooleanExpression isCompleted() {
-		return vote.endTime.before(LocalDateTime.now());
 	}
 
 	private BooleanExpression isPosted(final Long memberId) {


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 1️⃣ 버그 - Cursor 아이디와 size가 Swagger에서 필수값, json 형식으로 표시되는 문제
#### 문제
- Cursor Id와 사이즈는 필수가 아닌 옵션 쿼리 파라미터로 @ModelAttribute를 이용하여 DTO로 받고 있습니다. 
- 하지만 Swagger 상으로는 두 값이 json 형식으로 함께 받고 있으며, 필수 값으로 지정되어 있습니다.
- 찾아보니 SpringDoc 이슈이며, 저희가 의도한 대로 각각 쿼리 파라미터로 옵션으로 받기 위해서는 추가적인 작업이 필요하다고 나와있습니다.
 
#### 해결
- 일단 **각각의 값을 쿼리 파라미터로 사용**하기 위해, 컨트롤러의 매개변수 부분 또는 DTO 클래스단에 `@ParameterObject`를 추가하면 됩니다. 저희 서비스는 CursorRequest DTO가 공용으로 사용되기 때문에 DTO에 붙여줬습니다~!
- `@ParameterObject`를 적용하고 나니, **모든 필드를 String으로 인식하는 현상이 발생**하였습니다. 이 문제를 해결하기 위해 @Schema 대신 @Parameter로 대체하여 해결하였습니다!

#### Swagger
왼쪽 화면(기존), 오른쪽 화면(변경)
![image](https://github.com/uju-in/lime-backend/assets/98391539/1ee2efaf-703c-488f-8dfb-b473fc02033e)

#### 참고자료
https://yeonyeon.tistory.com/324

### 2️⃣ 버그 - 투표를 키워드로 검색하는 경우, 검색 결과가 잘못 나오는 문제
#### 문제
- `총 검색된 투표 수`와 `실제 검색되는 투표`가 일치하지 않는 문제가 있었습니다.
- 코드를 확인하니까 `총 검색된 투표 수`는 마감된 투표에 대해서만 count 하고, `실제 검색되는 투표`는 마감된 투표와 함께 진행 중인 투표도 보여주고 있었습니다.

#### 해결
- 팀 회의를 통해 마감 중인 투표와 진행 중인 투표를 모두 보여주기로 결정하여서, 그대로 코드를 수정했습니다!

### 3️⃣ 추가 요구사항 - 투표 제목을 통해서도 검색 가능하도록
- 기존에는 키워드를 입력하고, `키워드를 포함하는 투표 아이템`을 가진 투표에 대해서만 검색할 수 있었습니다.
- 투표 제목에 대해서도 검색할 수 있도록 요구사항을 추가하여, 그에 대한 코드도 추가하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
- 투표 검색 기능에서 투표 제목으로도 검색 가능하도록 변경됨