### PR TITLE
[LIME-133] default 폴더를 가장 뒤에 오도록 기능 추가

### DIFF
--- a/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderFavoriteInfoReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/item/implementation/MemberItemFolderFavoriteInfoReader.java
@@ -25,6 +25,8 @@ public class MemberItemFolderFavoriteInfoReader implements IFavoriteReader {
 	private static final int DEFAULT_IMAGE_SIZE = 3;
 
 	private final MemberItemReader memberItemReader;
+	private static final String DEFAULT_FOLDER_NAME = "default";
+
 	/*
 	 *
 	 * folder id 가 null 이면 root folder 를 의미한다.
@@ -33,15 +35,30 @@ public class MemberItemFolderFavoriteInfoReader implements IFavoriteReader {
 	 * */
 	@Override
 	public List<MemberItemFavoriteInfo> readFavorites(final Long folderId, final Long memberId) {
-
 		if (folderId != null) {
 			return Collections.emptyList();
 		}
 
 		List<MemberItemFolder> memberItemFolders = memberItemFolderReader.readMemberItemFoldersByMemberId(memberId);
+		moveDefaultFolderToEnd(memberItemFolders);
+
 		return memberItemFolders.stream()
 			.map(this::mapToMemberItemObjectInfo)
 			.toList();
+	}
+
+	private void moveDefaultFolderToEnd(final List<MemberItemFolder> memberItemFolders) {
+		List<MemberItemFolder> defaultFolders = new ArrayList<>();
+
+		memberItemFolders.removeIf(folder -> {
+			boolean isDefault = DEFAULT_FOLDER_NAME.equals(folder.getName());
+			if (isDefault) {
+				defaultFolders.add(folder);
+			}
+			return isDefault;
+		});
+
+		memberItemFolders.addAll(defaultFolders);
 	}
 
 	@Override


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

- 찜 목록 조회할 경우 default 폴더가 가장 뒤에 오도록 기능 추가 하였습니다. df88298e0bf55fee8952bb3bd4548fff4b88015f

### Issue Number

[ LIME-133]

### 기능 설명

- moveDefaultFolderToEnd 메서드에서 default 폴더를 뒤로 이동시킵니다.
- memberItemFolders에서 폴더 이름이 default인 경우 removeIf로 삭제하고 defaultFolders에 임시로 저장합니다.
- stream이 종료되면 memberItemFolders의 마지막에 임시로 저장한 defaultFolders를 추가합니다. 

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
