### PR TITLE
[LIME-131] 이벤트 비동기 처리를 통해 투표 로직과 레디스 로직 분리

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/LimeApplication.java
+++ b/lime-api/src/main/java/com/programmers/lime/LimeApplication.java
@@ -3,8 +3,10 @@ package com.programmers.lime;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @SpringBootApplication
 @EnableScheduling
 @ConfigurationPropertiesScan({"com.programmers.lime.global.config.security.jwt", "com.programmers.lime.domains.auth"})

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingAddEvent.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingAddEvent.java
@@ -1,0 +1,9 @@
+package com.programmers.lime.global.event.ranking.vote;
+
+import com.programmers.lime.redis.vote.VoteRankingInfo;
+
+public record RankingAddEvent(
+	String hobby,
+	VoteRankingInfo voteRankingInfo
+) {
+}

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingDecreasePopularityEvent.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingDecreasePopularityEvent.java
@@ -1,0 +1,9 @@
+package com.programmers.lime.global.event.ranking.vote;
+
+import com.programmers.lime.redis.vote.VoteRankingInfo;
+
+public record RankingDecreasePopularityEvent(
+	String hobby,
+	VoteRankingInfo voteRankingInfo
+) {
+}

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingDeleteEvent.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingDeleteEvent.java
@@ -1,0 +1,9 @@
+package com.programmers.lime.global.event.ranking.vote;
+
+import com.programmers.lime.redis.vote.VoteRankingInfo;
+
+public record RankingDeleteEvent(
+	String hobby,
+	VoteRankingInfo voteRankingInfo
+) {
+}

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingEventListener.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingEventListener.java
@@ -29,12 +29,12 @@ public class RankingEventListener {
 	@Async
 	@EventListener
 	public void decreasePopularity(final RankingDecreasePopularityEvent event) {
-		voteRedisManager.decreasePopularity(event.hobby(), event.voteRankingInfo());
+		voteRedisManager.updatePopularity(event.hobby(), event.voteRankingInfo(), -1);
 	}
 
 	@Async
 	@EventListener
 	public void deleteRanking(final RankingDeleteEvent event) {
-		voteRedisManager.remove(event.hobby(), event.voteRankingInfo());
+		voteRedisManager.deleteRanking(event.hobby(), event.voteRankingInfo());
 	}
 }

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingEventListener.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingEventListener.java
@@ -1,0 +1,40 @@
+package com.programmers.lime.global.event.ranking.vote;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.redis.vote.VoteRedisManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RankingEventListener {
+
+	private final VoteRedisManager voteRedisManager;
+
+	@Async
+	@EventListener
+	public void addRanking(final RankingAddEvent event) {
+		voteRedisManager.addRanking(event.hobby(), event.voteRankingInfo());
+	}
+
+	@Async
+	@EventListener
+	public void updateRanking(final RankingUpdateEvent event) {
+		voteRedisManager.updateRanking(event.hobby(), event.isVoting(), event.voteRankingInfo());
+	}
+
+	@Async
+	@EventListener
+	public void decreasePopularity(final RankingDecreasePopularityEvent event) {
+		voteRedisManager.decreasePopularity(event.hobby(), event.voteRankingInfo());
+	}
+
+	@Async
+	@EventListener
+	public void deleteRanking(final RankingDeleteEvent event) {
+		voteRedisManager.remove(event.hobby(), event.voteRankingInfo());
+	}
+}

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingUpdateEvent.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/vote/RankingUpdateEvent.java
@@ -1,0 +1,10 @@
+package com.programmers.lime.global.event.ranking.vote;
+
+import com.programmers.lime.redis.vote.VoteRankingInfo;
+
+public record RankingUpdateEvent(
+	String hobby,
+	boolean isVoting,
+	VoteRankingInfo voteRankingInfo
+) {
+}

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/MemberBuilder.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/MemberBuilder.java
@@ -17,7 +17,7 @@ public class MemberBuilder {
 
 	public static Member build(final Long memberId) {
 		final SocialInfo socialInfo = new SocialInfo(
-			"357935205",
+			357935205L,
 			"test@test.com",
 			"1.png",
 			SocialType.NAVER,

--- a/lime-infrastructure/src/main/java/com/programmers/lime/redis/vote/VoteRedisManager.java
+++ b/lime-infrastructure/src/main/java/com/programmers/lime/redis/vote/VoteRedisManager.java
@@ -27,18 +27,12 @@ public class VoteRedisManager {
 		redisTemplate.expire(KEY + hobby, 1, TimeUnit.DAYS);
 	}
 
-	public void increasePopularity(
+	public void updatePopularity(
 		final String hobby,
-		final VoteRankingInfo rankingInfo
+		final VoteRankingInfo rankingInfo,
+		final int delta
 	) {
-		redisTemplate.opsForZSet().incrementScore(KEY + hobby, rankingInfo, 1);
-	}
-
-	public void decreasePopularity(
-		final String hobby,
-		final VoteRankingInfo rankingInfo
-	) {
-		redisTemplate.opsForZSet().incrementScore(KEY + hobby, rankingInfo, -1);
+		redisTemplate.opsForZSet().incrementScore(KEY + hobby, rankingInfo, delta);
 	}
 
 	public List<VoteRankingInfo> getRanking(final String hobby) {
@@ -56,7 +50,7 @@ public class VoteRedisManager {
 			.toList();
 	}
 
-	public void remove(
+	public void deleteRanking(
 		final String hobby,
 		final VoteRankingInfo rankingInfo
 	) {
@@ -65,13 +59,13 @@ public class VoteRedisManager {
 
 	public void updateRanking(
 		final String hobby,
-		final boolean voting,
+		final boolean isVoting,
 		final VoteRankingInfo rankingInfo
 	) {
-		if (voting) {
-			increasePopularity(hobby, rankingInfo);
+		if (isVoting) {
+			updatePopularity(hobby, rankingInfo, 1);
 		} else {
-			remove(hobby, rankingInfo);
+			deleteRanking(hobby, rankingInfo);
 		}
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME-131
### 문제 상황
- 투표 로직이 정상적으로 처리 되어도 레디스에 문제가 생기면(예외가 터지면) 응답으로 예외 메시지를 보여준다.
- QA를 진행할 때, 투표를 생성하였는데 레디스 서버에 문제가 생겨서 응답으로 예외 메시지를 받았다. 하지만 투표는 정상적으로 생성되었다. (DB에 Insert 됨)

### 요구사항
- **투표 로직과 레디스 로직을 분리**하여, 레디스에 문제가 생겨도 응답은 정상적으로 내려주도록 변경한다.

### 처리 방법
> 이벤트 처리 + 비동기
- 레디스 로직들을 이벤트로 처리하여 투표 로직과 분리하였습니다.
- 하지만 이벤트는 기본적으로 동기로 작동하기 때문에, 예외가 전파됩니다. 이를 해결하기 위해 이벤트를 처리하는 메서드에 `@Async` 어노테이션을 붙여주어 비동기로 처리하였습니다.
- 비동기로 처리할 경우, 예외가 발생해도 호출 스레드로 예외가 전파되지 않습니다. 따라서 레디스 로직은 투표 로직에 영향을 미치지 않습니다.

### 고민했던 포인트
> `@TransactionalEventListener`을 사용하지 않은 이유
- `@TransactionalEventListener`는 default가 AFTER_COMMIT 입니다. 따라서 이 어노테이션을 사용하면 커밋된 후에 이벤트가 실행됩니다. 
- 하지만 VoteService 메서드들에는 `@Transactional`이 붙어있지 않아서 `@TransactionalEventListener`가 작동하지 않습니다.
- 또한 구현 계층 메서드에 `@Transactional`가 붙어있어 투표 로직들이 DB에 반영된 후(commit된 후), 이벤트가 실행됩니다. 따라서 이미 커밋 후 이벤트가 실행되기 때문에 `@TransactionalEventListener`를 사용하는 것과 같습니다.
- 투표 로직에서 예외가 발생한다면 이벤트도 발행되지 않습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
- 기존에는 레디스에서 예외가 발생하면 투표 로직이 정상 처리 되어도 응답으로 예외 메시지를 보여주었다. 하지만 현재는 레디스에 문제가 생겨도 투표 로직에 문제가 없으면 정상 응답을 내려준다.