### PR TITLE
[LIME-136] 피드 랭킹 업데이트 이벤트로 비동기 처리 기능 추가 

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/feed/FeedRankingUpdateEvent.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/feed/FeedRankingUpdateEvent.java
@@ -1,0 +1,9 @@
+package com.programmers.lime.global.event.ranking.feed;
+
+import com.programmers.lime.redis.feed.model.FeedRankingInfo;
+
+public record FeedRankingUpdateEvent(
+	FeedRankingInfo feedRankingInfo,
+	int value
+) {
+}

--- a/lime-api/src/main/java/com/programmers/lime/global/event/ranking/feed/FeedRankingUpdateEventListener.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/event/ranking/feed/FeedRankingUpdateEventListener.java
@@ -1,0 +1,22 @@
+package com.programmers.lime.global.event.ranking.feed;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.redis.feed.FeedRedisManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FeedRankingUpdateEventListener {
+
+	private final FeedRedisManager feedRedisManager;
+
+	@Async
+	@EventListener
+	public void updateFeedRanking(final FeedRankingUpdateEvent event) {
+		feedRedisManager.changePopularity(event.feedRankingInfo(), event.value());
+	}
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

###피드 랭킹 업데이트를 이벤트로 처리 하도록 기능 추가

### Issue Number

[LIME-136]

### 기능 설명

### 기존 코드 문제점과 해결방안
- 피드 생성, 좋아요, 싫어요를 할 경우 동기적으로 랭킹을 업데이트 해야 합니다.
- 하지만 사용자 관점에서 랭킹 업데이트가 될 때 까지 stop될 이유가 없었습니다.
- 이 문제점을 해결하기 위해 랭킹 업데이트 기능을 @Async를 사용하여 비동기적으로 실행되게 만들었습니다. 0e63c9dc42ea683060815ad4d1a0f79deceaee5a


## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-136]: https://uju-lime.atlassian.net/browse/LIME-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ