### PR TITLE
[LIME-141] 채팅방 목록 조회, 채팅방 참여, 채팅방 인원수 조회, 채팅방 나가기 기능 구현

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/ChatRoomController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/ChatRoomController.java
@@ -1,0 +1,63 @@
+package com.programmers.lime.domains.chatroom.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.programmers.lime.domains.chatroom.api.dto.response.ChatRoomGetListResponse;
+import com.programmers.lime.domains.chatroom.application.ChatRoomService;
+import com.programmers.lime.domains.chatroom.application.dto.response.ChatRoomGetServiceListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "chat-room", description = "채팅방 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chatrooms")
+public class ChatRoomController {
+
+	private final ChatRoomService chatRoomService;
+
+	//private final ChatService chatService;
+
+	@Operation(summary = "채티방 전체 조회", description = "채팅방을 조회합니다.")
+	@GetMapping
+	public ResponseEntity<ChatRoomGetListResponse> getChatRooms() {
+		ChatRoomGetServiceListResponse serviceResponse = chatRoomService.getAvailableChatRooms();
+		ChatRoomGetListResponse response = ChatRoomGetListResponse.from(serviceResponse);
+
+		return ResponseEntity.ok(
+			response
+		);
+	}
+
+	@Operation(summary = "채팅방 참여", description = "채팅방에 참여합니다.")
+	@PostMapping("/{chatRoomId}/join")
+	public ResponseEntity<Void> joinChatRoom(@PathVariable final Long chatRoomId) {
+		chatRoomService.joinChatRoom(chatRoomId);
+		//chatService.joinChatRoom(chatRoomId);
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "채팅방 인원수 조회", description = "채팅방의 인원수를 조회합니다.")
+	@GetMapping("/{chatRoomId}/members/count")
+	public ResponseEntity<Integer> countChatRoomMembers(@PathVariable final Long chatRoomId) {
+		return ResponseEntity.ok(
+			chatRoomService.countChatRoomMembersByChatRoomId(chatRoomId)
+		);
+	}
+
+	@Operation(summary = "채팅방 나가기", description = "채팅방에서 나갑니다.")
+	@DeleteMapping("/{chatRoomId}/exit")
+	public ResponseEntity<Void> exitChatRoom(@PathVariable final Long chatRoomId) {
+		chatRoomService.exitChatRoom(chatRoomId);
+		//chatService.sendExitMessageToChatRoom(chatRoomId);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/ChatRoomController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/ChatRoomController.java
@@ -26,7 +26,7 @@ public class ChatRoomController {
 
 	//private final ChatService chatService;
 
-	@Operation(summary = "채티방 전체 조회", description = "채팅방을 조회합니다.")
+	@Operation(summary = "채팅방 전체 조회", description = "채팅방을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<ChatRoomGetListResponse> getChatRooms() {
 		ChatRoomGetServiceListResponse serviceResponse = chatRoomService.getAvailableChatRooms();

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/dto/response/ChatRoomGetListResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/dto/response/ChatRoomGetListResponse.java
@@ -1,0 +1,16 @@
+package com.programmers.lime.domains.chatroom.api.dto.response;
+
+import java.util.List;
+
+import com.programmers.lime.domains.chatroom.application.dto.response.ChatRoomGetServiceListResponse;
+import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
+
+public record ChatRoomGetListResponse(
+	List<ChatRoomInfo> chatRoomInfos
+) {
+	public static ChatRoomGetListResponse from(ChatRoomGetServiceListResponse chatRoomGetServiceListResponse) {
+		return new ChatRoomGetListResponse(
+			chatRoomGetServiceListResponse.chatRoomInfos()
+		);
+	}
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/dto/response/ChatRoomGetListResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/api/dto/response/ChatRoomGetListResponse.java
@@ -8,7 +8,7 @@ import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
 public record ChatRoomGetListResponse(
 	List<ChatRoomInfo> chatRoomInfos
 ) {
-	public static ChatRoomGetListResponse from(ChatRoomGetServiceListResponse chatRoomGetServiceListResponse) {
+	public static ChatRoomGetListResponse from(final ChatRoomGetServiceListResponse chatRoomGetServiceListResponse) {
 		return new ChatRoomGetListResponse(
 			chatRoomGetServiceListResponse.chatRoomInfos()
 		);

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/ChatRoomService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/ChatRoomService.java
@@ -1,0 +1,92 @@
+package com.programmers.lime.domains.chatroom.application;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.programmers.lime.domains.chatroom.application.dto.response.ChatRoomGetServiceListResponse;
+import com.programmers.lime.domains.chatroom.implementation.ChatRoomMemberAppender;
+import com.programmers.lime.domains.chatroom.implementation.ChatRoomMemberReader;
+import com.programmers.lime.domains.chatroom.implementation.ChatRoomMemberRemover;
+import com.programmers.lime.domains.chatroom.implementation.ChatRoomReader;
+import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.ErrorCode;
+import com.programmers.lime.global.config.chat.WebSocketSessionManager;
+import com.programmers.lime.global.config.security.SecurityUtils;
+import com.programmers.lime.redis.chat.ChatSessionRedisManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+	private final ChatRoomMemberReader chatRoomMemberReader;
+
+	private final ChatRoomMemberAppender chatRoomMemberAppender;
+
+	private final ChatRoomMemberRemover chatRoomMemberRemover;
+
+	private final ChatRoomReader chatRoomReader;
+
+	private final WebSocketSessionManager webSocketSessionManager;
+
+	private final ChatSessionRedisManager chatSessionRedisManager;
+
+	public ChatRoomGetServiceListResponse getAvailableChatRooms() {
+		Long memberId = SecurityUtils.getCurrentMemberId();
+
+		List<ChatRoomInfo> chatRoomInfos = null;
+
+		if(Objects.isNull(memberId)) {
+			chatRoomInfos = chatRoomReader.readOpenChatRooms();
+		} else {
+			chatRoomInfos = chatRoomReader.readOpenChatRoomsByMemberId(memberId);
+		}
+
+		return new ChatRoomGetServiceListResponse(
+			chatRoomInfos
+		);
+	}
+
+	public void joinChatRoom(Long chatRoomId) {
+
+		Long memberId = SecurityUtils.getCurrentMemberId();
+
+		if(Objects.isNull(memberId)) {
+			throw new BusinessException(ErrorCode.MEMBER_ANONYMOUS);
+		}
+
+		if(chatRoomMemberReader.existMemberByMemberIdAndRoomId(chatRoomId, memberId)) {
+			throw new BusinessException(ErrorCode.CHATROOM_ALREADY_JOIN);
+		}
+
+		chatRoomMemberAppender.appendChatRoomMember(chatRoomId, memberId);
+	}
+
+	public int countChatRoomMembersByChatRoomId(Long chatRoomId) {
+		return chatRoomMemberReader.countChatRoomMembersByChatRoomId(chatRoomId);
+	}
+
+	public void exitChatRoom(Long chatRoomId) {
+		Long memberId = SecurityUtils.getCurrentMemberId();
+
+		Set<String> sessionIdsByMemberAndRoom = chatSessionRedisManager.getSessionIdsByMemberAndRoom(
+			memberId,
+			chatRoomId
+		);
+
+		for(String memberSessionId : sessionIdsByMemberAndRoom) {
+			try {
+				webSocketSessionManager.closeSession(memberSessionId);
+			} catch (Exception e) {
+				throw new BusinessException(ErrorCode.CHAT_SESSION_NOT_FOUND);
+			}
+		}
+
+		chatRoomMemberRemover.removeChatRoomMember(chatRoomId, memberId);
+	}
+}

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/ChatRoomService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/ChatRoomService.java
@@ -39,14 +39,7 @@ public class ChatRoomService {
 	public ChatRoomGetServiceListResponse getAvailableChatRooms() {
 		Long memberId = SecurityUtils.getCurrentMemberId();
 
-		List<ChatRoomInfo> chatRoomInfos = null;
-
-		if(Objects.isNull(memberId)) {
-			chatRoomInfos = chatRoomReader.readOpenChatRooms();
-		} else {
-			chatRoomInfos = chatRoomReader.readOpenChatRoomsByMemberId(memberId);
-		}
-
+		List<ChatRoomInfo> chatRoomInfos = chatRoomReader.readOpenChatRoomsByMemberId(memberId);
 		return new ChatRoomGetServiceListResponse(
 			chatRoomInfos
 		);

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/ChatRoomService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/ChatRoomService.java
@@ -45,7 +45,7 @@ public class ChatRoomService {
 		);
 	}
 
-	public void joinChatRoom(Long chatRoomId) {
+	public void joinChatRoom(final Long chatRoomId) {
 
 		Long memberId = SecurityUtils.getCurrentMemberId();
 
@@ -64,7 +64,7 @@ public class ChatRoomService {
 		return chatRoomMemberReader.countChatRoomMembersByChatRoomId(chatRoomId);
 	}
 
-	public void exitChatRoom(Long chatRoomId) {
+	public void exitChatRoom(final Long chatRoomId) {
 		Long memberId = SecurityUtils.getCurrentMemberId();
 
 		Set<String> sessionIdsByMemberAndRoom = chatSessionRedisManager.getSessionIdsByMemberAndRoom(

--- a/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/dto/response/ChatRoomGetServiceListResponse.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/chatroom/application/dto/response/ChatRoomGetServiceListResponse.java
@@ -1,0 +1,10 @@
+package com.programmers.lime.domains.chatroom.application.dto.response;
+
+import java.util.List;
+
+import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
+
+public record ChatRoomGetServiceListResponse(
+	List<ChatRoomInfo> chatRoomInfos
+) {
+}

--- a/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
+++ b/lime-common/src/main/java/com/programmers/lime/error/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
 	S3_UPLOAD_FAIL("COMMON_014", "S3 업로드에 실패했습니다."),
 	S3_DELETE_FAIL("COMMON_015", "S3 삭제에 실패했습니다."),
 	BAD_REVIEW_IMAGE_URL("COMMON_016", "잘못된 리뷰 이미지 URL 입니다."),
+	INVALID_SUBSCRIPTION_DESTINATION("COMMON_017", "유효하지 않은 구독 대상입니다."),
+	MESSAGE_DOMAIN_TYPE_NOT_FOUND("COMMON_018", "메시지 도메인 타입을 찾을 수 없습니다."),
+	SUBSCRIPTION_DESTINATION_NOT_FOUND("COMMON_019", "구독 대상을 찾을 수 없습니다."),
 
 
 	// Member
@@ -134,7 +137,15 @@ public enum ErrorCode {
 
 	// Favorite
 	FAVORITE_TYPE_BAD_REQUEST("FAVORITE_001", "잘못된 favoriteType 파라미터 값입니다."),
-	;
+
+	// ChatRoom
+	CHATROOM_MAX_MEMBER_COUNT_ERROR("CHATROOM_001","최소 2명 이상의 사용자가 필요합니다." ),
+	CHATROOM_ALREADY_JOIN("CHATROOM_002","이미 참여한 채팅방 입니다." ),
+	CHATROOM_NOT_PERMISSION("CHATROOM_003","채팅방에 참여할 권한이 없습니다." ),
+
+	// Chat
+	CHAT_NOT_PERMISSION("CHAT_001","채팅 권한이 없습니다." ),
+	CHAT_SESSION_NOT_FOUND("CHAT_002","채팅 세션을 찾을 수 없습니다." );
 
 	private static final Map<String, ErrorCode> ERROR_CODE_MAP;
 

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/domain/ChatRoom.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/domain/ChatRoom.java
@@ -1,0 +1,70 @@
+package com.programmers.lime.domains.chatroom.domain;
+
+import java.util.Objects;
+
+import com.programmers.lime.domains.BaseEntity;
+import com.programmers.lime.domains.chatroom.model.ChatRoomStatus;
+import com.programmers.lime.domains.chatroom.model.ChatRoomType;
+import com.programmers.lime.error.BusinessException;
+import com.programmers.lime.error.ErrorCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_rooms")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+	private static final int MIN_ROOM_MAX_MEMBER_COUNT = 2;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "room_name", nullable = false)
+	private String roomName;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "room_type", nullable = false)
+	private ChatRoomType chatRoomType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "room_status", nullable = false)
+	private ChatRoomStatus chatRoomStatus;
+
+	@Column(name = "room_max_member_count", nullable = false)
+	private int roomMaxMemberCount;
+
+	@Builder
+	public ChatRoom(
+		final String roomName,
+		final ChatRoomType chatRoomType,
+		final ChatRoomStatus chatRoomStatus,
+		final int roomMaxMemberCount
+	) {
+		validRoomMaxMemberCount(roomMaxMemberCount);
+		this.roomName = Objects.requireNonNull(roomName);
+		this.chatRoomType = Objects.requireNonNull(chatRoomType);
+		this.chatRoomStatus = Objects.requireNonNull(chatRoomStatus);
+		this.roomMaxMemberCount = roomMaxMemberCount;
+	}
+
+	private void validRoomMaxMemberCount(int roomMaxMemberCount) {
+		if (roomMaxMemberCount < MIN_ROOM_MAX_MEMBER_COUNT) {
+			throw new BusinessException(ErrorCode.CHATROOM_MAX_MEMBER_COUNT_ERROR);
+		}
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/domain/ChatRoomMember.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/domain/ChatRoomMember.java
@@ -1,0 +1,36 @@
+package com.programmers.lime.domains.chatroom.domain;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_room_members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "chat_room_id", nullable = false)
+	private Long chatRoomId;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	public ChatRoomMember(final Long chatRoomId, final Long memberId) {
+		this.chatRoomId = Objects.requireNonNull(chatRoomId);
+		this.memberId = Objects.requireNonNull(memberId);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomMemberAppender.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomMemberAppender.java
@@ -1,0 +1,23 @@
+package com.programmers.lime.domains.chatroom.implementation;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.chatroom.domain.ChatRoomMember;
+import com.programmers.lime.domains.chatroom.repository.ChatRoomMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomMemberAppender {
+
+	private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+	public void appendChatRoomMember(
+		final Long chatRoomId,
+		final Long memberId
+	) {
+		ChatRoomMember chatRoomMember = new ChatRoomMember(chatRoomId, memberId);
+		chatRoomMemberRepository.save(chatRoomMember);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomMemberReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomMemberReader.java
@@ -1,0 +1,28 @@
+package com.programmers.lime.domains.chatroom.implementation;
+
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.programmers.lime.domains.chatroom.repository.ChatRoomMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomMemberReader {
+
+	private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+	public int countChatRoomMembersByChatRoomId(final Long chatRoomId) {
+		return chatRoomMemberRepository.countChatRoomMembersByChatRoomId(chatRoomId);
+	}
+
+	public boolean existMemberByMemberIdAndRoomId(
+		final Long chatRoomId,
+		final Long memberId
+	) {
+		return chatRoomMemberRepository.existsAllByChatRoomIdAndMemberId(chatRoomId, memberId);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomMemberRemover.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomMemberRemover.java
@@ -1,0 +1,23 @@
+package com.programmers.lime.domains.chatroom.implementation;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.programmers.lime.domains.chatroom.repository.ChatRoomMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomMemberRemover {
+
+	private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+	@Transactional
+	public void removeChatRoomMember(
+		final Long chatRoomId,
+		final Long memberId
+	) {
+		chatRoomMemberRepository.deleteByChatRoomIdAndMemberId(chatRoomId, memberId);
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomReader.java
@@ -1,0 +1,25 @@
+package com.programmers.lime.domains.chatroom.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
+import com.programmers.lime.domains.chatroom.repository.ChatRoomRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomReader {
+
+	private final ChatRoomRepository chatRoomRepository;
+
+	public List<ChatRoomInfo> readOpenChatRoomsByMemberId(Long memberId) {
+		return chatRoomRepository.findOpenChatRoomsIncludingWithoutMembers(memberId);
+	}
+
+	public List<ChatRoomInfo> readOpenChatRooms() {
+		return chatRoomRepository.findOpenChatRooms();
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomReader.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/implementation/ChatRoomReader.java
@@ -16,10 +16,9 @@ public class ChatRoomReader {
 	private final ChatRoomRepository chatRoomRepository;
 
 	public List<ChatRoomInfo> readOpenChatRoomsByMemberId(Long memberId) {
-		return chatRoomRepository.findOpenChatRoomsIncludingWithoutMembers(memberId);
-	}
-
-	public List<ChatRoomInfo> readOpenChatRooms() {
+		if(memberId != null) {
+			return chatRoomRepository.findOpenChatRoomsIncludingWithoutMembers(memberId);
+		}
 		return chatRoomRepository.findOpenChatRooms();
 	}
 }

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/model/ChatRoomInfo.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/model/ChatRoomInfo.java
@@ -1,0 +1,12 @@
+package com.programmers.lime.domains.chatroom.model;
+
+public record ChatRoomInfo(
+	Long chatRoomId,
+	String chatRoomName,
+	ChatRoomType chatRoomType,
+	ChatRoomStatus chatRoomStatus,
+	int roomMaxMemberCount,
+	boolean isJoined,
+	Long currentMemberCount
+) {
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/model/ChatRoomStatus.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/model/ChatRoomStatus.java
@@ -1,0 +1,16 @@
+package com.programmers.lime.domains.chatroom.model;
+
+public enum ChatRoomStatus {
+
+	OPEN("열림"),
+	CLOSE("닫힘");
+	private final String description;
+
+	ChatRoomStatus(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/model/ChatRoomType.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/model/ChatRoomType.java
@@ -1,0 +1,16 @@
+package com.programmers.lime.domains.chatroom.model;
+
+public enum ChatRoomType {
+
+	PRIVATE("비공개"),
+	PUBLIC("공개");
+	private final String description;
+
+	ChatRoomType(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomMemberRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,20 @@
+package com.programmers.lime.domains.chatroom.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.programmers.lime.domains.chatroom.domain.ChatRoomMember;
+
+public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
+
+	int countChatRoomMembersByChatRoomId(final Long chatRoomId);
+
+	boolean existsAllByChatRoomIdAndMemberId(
+		final Long chatRoomId,
+		final Long memberId
+	);
+
+	void deleteByChatRoomIdAndMemberId(
+		final Long chatRoomId,
+		final Long memberId
+	);
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomQueryDsl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomQueryDsl.java
@@ -1,0 +1,12 @@
+package com.programmers.lime.domains.chatroom.repository;
+
+import java.util.List;
+
+import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
+
+public interface ChatRoomQueryDsl {
+
+	List<ChatRoomInfo> findOpenChatRoomsIncludingWithoutMembers(Long memberId);
+
+	List<ChatRoomInfo> findOpenChatRooms();
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomQueryDslImpl.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomQueryDslImpl.java
@@ -1,0 +1,71 @@
+package com.programmers.lime.domains.chatroom.repository;
+
+import java.util.List;
+
+import static com.programmers.lime.domains.chatroom.domain.QChatRoom.*;
+import static com.programmers.lime.domains.chatroom.domain.QChatRoomMember.*;
+import static com.querydsl.core.types.ExpressionUtils.*;
+
+import com.programmers.lime.domains.chatroom.model.ChatRoomInfo;
+import com.programmers.lime.domains.chatroom.model.ChatRoomStatus;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChatRoomQueryDslImpl implements ChatRoomQueryDsl {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<ChatRoomInfo> findOpenChatRoomsIncludingWithoutMembers(final Long memberId) {
+		return jpaQueryFactory
+			.select(Projections.constructor(ChatRoomInfo.class,
+				chatRoom.id.as("chatRoomId"),
+				chatRoom.roomName.as("chatRoomName"),
+				chatRoom.chatRoomType.as("chatRoomType"),
+				chatRoom.chatRoomStatus.as("chatRoomStatus"),
+				chatRoom.roomMaxMemberCount.as("roomMaxMemberCount"),
+				chatRoomMember.memberId.coalesce(0L).goe(1L).as("isJoined"),
+				JPAExpressions
+					.select(count(chatRoomMember.chatRoomId))
+					.from(chatRoomMember)
+					.where(
+						chatRoom.id.eq(chatRoomMember.chatRoomId)
+					)
+			))
+			.from(chatRoom)
+			.leftJoin(chatRoomMember).on(chatRoom.id.eq(chatRoomMember.chatRoomId)
+				.and(chatRoomMember.memberId.eq(memberId)))
+			.where(chatRoom.chatRoomStatus.eq(ChatRoomStatus.OPEN))
+			.groupBy(chatRoom.id)
+			.fetch();
+	}
+
+	@Override
+	public List<ChatRoomInfo> findOpenChatRooms() {
+		return jpaQueryFactory
+			.select(Projections.constructor(ChatRoomInfo.class,
+				chatRoom.id.as("chatRoomId"),
+				chatRoom.roomName.as("chatRoomName"),
+				chatRoom.chatRoomType.as("chatRoomType"),
+				chatRoom.chatRoomStatus.as("chatRoomStatus"),
+				chatRoom.roomMaxMemberCount.as("roomMaxMemberCount"),
+				Expressions.constant(false),
+				JPAExpressions
+					.select(count(chatRoomMember.chatRoomId))
+					.from(chatRoomMember)
+					.where(
+						chatRoom.id.eq(chatRoomMember.chatRoomId)
+					)
+			))
+			.from(chatRoom)
+			.where(chatRoom.chatRoomStatus.eq(ChatRoomStatus.OPEN))
+			.fetch();
+	}
+
+
+}

--- a/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomRepository.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,12 @@
+package com.programmers.lime.domains.chatroom.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.programmers.lime.domains.chatroom.domain.ChatRoom;
+
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryDsl{
+
+
+
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

#### 총 네 가지의 기능이 추가 되었습니다.
- 채팅방 목록 조회(전체
- 채팅방 참여
- 채팅방 인원수 조회
- 채팅방 나가기 기능 

### Issue Number

[LIME-141]

### 기능 설명

#### 채팅방 목록 조회(전체)
- 데이터 베이스에 있는 참여 가능한 전체 채팅방을 조회 합니다.
- memberId가 있는 경우와 없는 경우를 나눠서 조회 합니다.
- memberId가 있는 경우 chat_rooms과 chat_room_members 테이블과 left join 하여 입력으로 받은 memberId가 일치하는지 확인합니다. 이 때 일치하는 memberId가 chat_room_members에 있다면 isJoined를 true 반환하고 아니면 false로 반환 합니다.
- memberId가 없는 경우 위 작업을 생략하고 isJoined를 false로 반환 합니다.
- 채팅방 목록 조회 요구사항이 복잡해서  Querydsl로 구현 하였습니다.

#### 채팅방 참여
-  room id는 path variable로 받고 token은 헤더에서 가져와 처리합니다.
- jpa repository의 save 메서드를 사용하여 저장합니다ㅏ.

#### 채팅방 인원수 조회 
-  room id를 입력받아 chat_rooom_members 테이블을 조회하여 일치하는  room id의 개수를 반환 합니다.

#### 채팅방 나가기
- room id는 path variable로 받고 token은 헤더에서 가져와 처리합니다.
- chat_room_members 테이블에 room id와 일치하는 row를 삭제합니다. 


<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[LIME-141]: https://uju-lime.atlassian.net/browse/LIME-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ