### PR TITLE
[LIME-144] 마이 투표 요구사항 변경

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
@@ -93,13 +93,11 @@ public class VoteController {
 	@GetMapping
 	public ResponseEntity<VoteGetByCursorResponse> getVotesByCursor(
 		@RequestParam final String hobby,
-		@RequestParam(required = false, name = "status") final String statusCondition,
 		@RequestParam(required = false, name = "sort") final String sortCondition,
 		@ModelAttribute final CursorRequest request
 	) {
 		final CursorSummary<VoteSummary> cursorSummary = voteService.getVotesByCursor(
 			Hobby.from(hobby),
-			VoteStatusCondition.from(statusCondition),
 			VoteSortCondition.from(sortCondition),
 			request.toParameters()
 		);

--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/api/VoteController.java
@@ -129,4 +129,23 @@ public class VoteController {
 
 		return ResponseEntity.ok(response);
 	}
+
+	@Operation(summary = "마이 투표 목록 조회(커서)", description = "취미, 상태 조건, 커서 요청 정보를 이용하여 마이 투표를 조회합니다.")
+	@GetMapping("/{nickname}/my")
+	public ResponseEntity<VoteGetByCursorResponse> getMyVotesByCursor(
+		@PathVariable final String nickname,
+		@RequestParam final String hobby,
+		@RequestParam(name = "status") final String statusCondition,
+		@ModelAttribute final CursorRequest request
+	) {
+		final CursorSummary<VoteSummary> cursorSummary = voteService.getMyVotesByCursor(
+			nickname,
+			Hobby.from(hobby),
+			VoteStatusCondition.from(statusCondition),
+			request.toParameters()
+		);
+		final VoteGetByCursorResponse response = VoteGetByCursorResponse.from(cursorSummary);
+
+		return ResponseEntity.ok(response);
+	}
 }

--- a/lime-api/src/main/java/com/programmers/lime/domains/vote/application/VoteService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/vote/application/VoteService.java
@@ -133,19 +133,14 @@ public class VoteService {
 
 	public CursorSummary<VoteSummary> getVotesByCursor(
 		final Hobby hobby,
-		final VoteStatusCondition statusCondition,
 		final VoteSortCondition sortCondition,
 		final CursorPageParameters parameters
 	) {
 		final Long memberId = memberUtils.getCurrentMemberId();
 
-		if (memberId == null && statusCondition != null && statusCondition.isRequiredLogin()) {
-			throw new BusinessException(ErrorCode.UNAUTHORIZED);
-		}
-
 		return voteReader.readByCursor(
 			hobby,
-			statusCondition,
+			null,
 			sortCondition,
 			null,
 			parameters,
@@ -188,11 +183,11 @@ public class VoteService {
 	) {
 		Long memberId = memberUtils.getCurrentMemberId();
 
-		if (memberId == null && statusCondition != null && statusCondition.isRequiredLogin()) {
+		if (memberId == null && statusCondition.isRequiredLogin()) {
 			throw new BusinessException(ErrorCode.UNAUTHORIZED);
 		}
 
-		if (memberId == null) {
+		if (statusCondition == VoteStatusCondition.POSTED) {
 			memberId = memberReader.readByNickname(nickname).getId();
 		}
 

--- a/lime-api/src/main/java/com/programmers/lime/global/config/security/SecurityConfiguration.java
+++ b/lime-api/src/main/java/com/programmers/lime/global/config/security/SecurityConfiguration.java
@@ -55,6 +55,7 @@ public class SecurityConfiguration {
 
 					.requestMatchers(HttpMethod.GET, "/api/votes").permitAll()
 					.requestMatchers(HttpMethod.GET, "/api/votes/{voteId}").permitAll()
+					.requestMatchers(HttpMethod.GET, "/api/votes/{nickname}/my").permitAll()
 
 					.requestMatchers("/api/reviews/**").permitAll()
 					.requestMatchers("/api/items/{itemId}").permitAll()

--- a/lime-domain/src/main/java/com/programmers/lime/domains/vote/model/VoteStatusCondition.java
+++ b/lime-domain/src/main/java/com/programmers/lime/domains/vote/model/VoteStatusCondition.java
@@ -40,6 +40,6 @@ public enum VoteStatusCondition {
 	}
 
 	public boolean isRequiredLogin() {
-		return this == POSTED || this == PARTICIPATED;
+		return this == PARTICIPATED;
 	}
 }

--- a/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/setup/MemberSetUp.java
+++ b/lime-domain/src/testFixtures/java/com/programmers/lime/domains/member/domain/setup/MemberSetUp.java
@@ -1,0 +1,22 @@
+package com.programmers.lime.domains.member.domain.setup;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.lime.domains.member.domain.Member;
+import com.programmers.lime.domains.member.domain.MemberBuilder;
+import com.programmers.lime.domains.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberSetUp {
+
+	private final MemberRepository memberRepository;
+
+	public Member saveOne(final Long memberId) {
+		final Member member = MemberBuilder.build(memberId);
+
+		return memberRepository.save(member);
+	}
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [x]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME-144

### ✨ 요구사항 설명 ✨
1. 올린 투표는 로그인 없어도 조회 가능하도록 변경
2. 내가 참여한 투표는 로그인 상태에서만 확인 가능 (기존의 요구사항과 동일)

### b96220494a72a1a5f244337aa539ab04949330ee
- 마이 투표 목록 조회 기능을 기존의 투표 목록 조회와 분리하였습니다.
    - 분리한 이유는 마이 투표만 닉네임을 따로 받아야 하기 때문입니다. 기존의 기능에 추가하기에는 너무 복잡해질 것 같아서 분리하는 게 좋다고 생각하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
- 기존의 투표 목록 조회에서 내가 올린 투표, 내가 참여한 투표 목록을 조회할 수 없도록 변경하였습니다. 이제 올린 투표와 참여한 투표는 마이 투표 기능에서만 확인 가능합니다.