### PR TITLE
[LIME-165] Refresh Token 저장소 레디스로 변경

### DIFF
--- a/lime-api/src/main/java/com/programmers/lime/domains/auth/application/OAuthUserService.java
+++ b/lime-api/src/main/java/com/programmers/lime/domains/auth/application/OAuthUserService.java
@@ -9,7 +9,7 @@ import com.programmers.lime.domains.member.domain.Member;
 import com.programmers.lime.domains.member.domain.vo.SocialType;
 import com.programmers.lime.domains.member.implementation.MemberAppender;
 import com.programmers.lime.domains.member.implementation.MemberReader;
-import com.programmers.lime.global.config.security.jwt.JwtService;
+import com.programmers.lime.global.config.security.SecurityManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +20,7 @@ public class OAuthUserService {
 	private final KakaoOAuthClient kakaoOAuthClient;
 	private final MemberAppender memberAppender;
 	private final MemberReader memberReader;
-	private final JwtService jwtService;
+	private final SecurityManager securityManager;
 
 	@Transactional
 	public MemberLoginServiceResponse login(final String code) {
@@ -32,8 +32,8 @@ public class OAuthUserService {
 			SocialType.KAKAO
 		).orElseGet(() -> saveMember(response));
 
-		String accessToken = jwtService.generateAccessToken(String.valueOf(foundMember.getId()));
-		String refreshToken = jwtService.generateRefreshToken();
+		String accessToken = securityManager.generateAccessToken(foundMember.getId());
+		String refreshToken = securityManager.generateRefreshToken(foundMember.getId());
 
 		return MemberLoginServiceResponse.from(foundMember, accessToken, refreshToken);
 	}

--- a/lime-infrastructure/src/main/java/com/programmers/lime/redis/token/RefreshTokenManager.java
+++ b/lime-infrastructure/src/main/java/com/programmers/lime/redis/token/RefreshTokenManager.java
@@ -1,0 +1,35 @@
+package com.programmers.lime.redis.token;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenManager {
+
+	public static final int EXPIRE_TIME = 1209600;
+	public static final String key = "REFRESH_TOKEN_";
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void addRefreshToken(
+		final String refreshToken,
+		final Long memberId
+	) {
+		redisTemplate.opsForValue().set(key + refreshToken, memberId);
+		redisTemplate.expire(key + refreshToken, EXPIRE_TIME, TimeUnit.SECONDS);
+	}
+
+	public Long getMemberId(final String refreshToken) {
+		Object memberId = redisTemplate.opsForValue().get(key + refreshToken);
+
+		return memberId == null ? null : ((Integer) memberId).longValue();
+	}
+
+	public void deleteRefreshToken(final String refreshToken) {
+		redisTemplate.delete(key + refreshToken);
+	}
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

LIME-165

### 기능 설명
#### [카카오 로그인 시 리프레시 토큰 저장하도록 변경](https://github.com/uju-in/lime-backend/pull/89/commits/32ee616174c9138f498821a1c9c8af44b6bef176)
- 카카오 로그인 시 리프레시 토큰을 저장하지 않던 버그를 수정했습니다.

#### [리프레시 토큰 저장소 레디스로 변경](https://github.com/uju-in/lime-backend/pull/89/commits/79331084ed5ccf3f207496c25b22f36434340cf8)
- 서버가 1대에서 2대로 스케일 아웃 되면서 더 이상 리프레시 토큰 저장소로 로컬 캐시를 사용할 수 없어 레디스로 변경하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
